### PR TITLE
Add context to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ the experiment will be either:
 - Released as a Core Integration,
 - Dropped.
 
+## Experiments catalog
+
+The latest version of the package contains the following experiments:
+
+| Name                     | Type                    | Experiment end date |
+| ------------------------ | ----------------------- | ------------------- |
+| [`EvaluationHarness`][1] | Evaluation orchestrator | August 2024         |
+
+[1]: https://github.com/deepset-ai/haystack-experimental/tree/main/haystack_experimental/evaluation/harness
+
 ## Usage
 
 Experimental new features can be imported like any other Haystack integration package:
@@ -58,7 +68,7 @@ pipe.run(...)
 
 ## Documentation
 
-Documentation for `haystack-experimental` can be found [here](https://docs.haystack.deepset.ai/reference/haystack-experimental-api)
+Documentation for `haystack-experimental` can be found [here](https://docs.haystack.deepset.ai/reference/haystack-experimental-api).
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@
 
 The `haystack-experimental` package provides Haystack users with access to experimental features without immediately
 committing to their official release. The main goal is to gather user feedback and iterate on new features quickly.
-For simplicity, every release of `haystack-experimental` will ship all the available experiments at that time.
+
+## Installation
+
+For simplicity, every release of `haystack-experimental` will ship all the available experiments at that time. To
+install the latest experimental features, run:
+
+```sh
+$ pip install -U haystack-experimental
+```
+
+> [!IMPORTANT]
+> The latest version of the experimental package is only tested against the latest version of Haystack. Compatibility
+> with older version of Haystack is not guaranteed.
+
 
 ## Experiments lifecycle
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ pipe = Pipeline()
 pipe.run(...)
 ```
 
+## Documentation
+
+Documentation for `haystack-experimental` can be found [here](https://docs.haystack.deepset.ai/reference/haystack-experimental-api)
+
 ## Implementation
 
 Experiments should try to replicate the namespace of the core package. For example, a new generator:
@@ -95,10 +99,6 @@ class Pipeline(HaystackPipeline):
         return super().to_dict()
 
 ```
-## Documentation
-
-Documentation for `haystack-experimental` can be found [here](https://docs.haystack.deepset.ai/reference/haystack-experimental-api)
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ $ pip install -U haystack-experimental
 
 > [!IMPORTANT]
 > The latest version of the experimental package is only tested against the latest version of Haystack. Compatibility
-> with older version of Haystack is not guaranteed.
+> with older versions of Haystack is not guaranteed.
 
 
 ## Experiments lifecycle
 
 Any experimental feature will be removed from `haystack-experimental` after a period of 3 months. After this time,
 the experiment will be either:
-- Incorporated in Haystack and released with the next minor,
+- Merged into Haystack core and published in the next minor release
 - Released as a Core Integration,
 - Dropped.
 
@@ -54,7 +54,7 @@ c = FoobarGenerator()
 c.run([ChatMessage.from_user("What's an experiment? Be brief.")])
 ```
 
-Experiments can also override existing Haystack features. For example, users opt-in for an experimental type of
+Experiments can also override existing Haystack features. For example, users can opt into an experimental type of
 `Pipeline` by just changing the usual import:
 
 ```python
@@ -72,7 +72,7 @@ Documentation for `haystack-experimental` can be found [here](https://docs.hayst
 
 ## Implementation
 
-Experiments should try to replicate the namespace of the core package. For example, a new generator:
+Experiments should replicate the namespace of the core package. For example, a new generator:
 
 ```python
 # in haystack_experimental/components/generators/foobar.py
@@ -112,5 +112,4 @@ class Pipeline(HaystackPipeline):
 
 ## Contributing
 
-Direct contributions to `haystack-experimental` are not expected, but Haystack maintainers might ask you to move here
-a pull request that you originally opened on https://github.com/deepset-ai/haystack.
+Direct contributions to `haystack-experimental` are not expected, but Haystack maintainers might ask contributors to move pull requests that target the [core repository](https://github.com/deepset-ai/haystack) to this repository.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,93 @@
-# haystack-experimental
-
 [![PyPI - Version](https://img.shields.io/pypi/v/haystack-experimental.svg)](https://pypi.org/project/haystack-experimental)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/haystack-experimental.svg)](https://pypi.org/project/haystack-experimental)
 [![Tests](https://github.com/deepset-ai/haystack-experimental/actions/workflows/tests.yml/badge.svg)](https://github.com/deepset-ai/haystack-experimental/actions/workflows/tests.yml)
 [![Project release on PyPi](https://github.com/deepset-ai/haystack-experimental/actions/workflows/pypi_release.yml/badge.svg)](https://github.com/deepset-ai/haystack-experimental/actions/workflows/pypi_release.yml)
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+
+# Haystack experimental package
+
+The `haystack-experimental` package provides Haystack users with access to experimental features without immediately
+committing to their official release. The main goal is to gather user feedback and iterate on new features quickly.
+For simplicity, every release of `haystack-experimental` will ship all the available experiments at that time.
+
+## Experiments lifecycle
+
+Any experimental feature will be removed from `haystack-experimental` after a period of 3 months. After this time,
+the experiment will be either:
+- Incorporated in Haystack and released with the next minor,
+- Released as a Core Integration,
+- Dropped.
+
+## Usage
+
+Experimental new features can be imported like any other Haystack integration package:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_experimental.components.generators import FoobarGenerator
+
+c = FoobarGenerator()
+c.run([ChatMessage.from_user("What's an experiment? Be brief.")])
+```
+
+Experiments can also override existing Haystack features. For example, users opt-in for an experimental type of
+`Pipeline` by just changing the usual import:
+
+```python
+# from haystack import Pipeline
+from haystack_experimental import Pipeline
+
+pipe = Pipeline()
+# ...
+pipe.run(...)
+```
+
+## Implementation
+
+Experiments should try to replicate the namespace of the core package. For example, a new generator:
+
+```python
+# in haystack_experimental/components/generators/foobar.py
+
+from haystack import component
+
+
+@component
+class FoobarGenerator:
+    ...
+
+```
+
+When the experiment overrides an existing feature, the new symbol should be created at the same path in the experimental
+package. This new symbol will override the original in `haystack-ai`: for classes, with a subclass and for bare
+functions, with a wrapper. For example:
+
+```python
+# in haystack_experiment/src/haystack_experiment/core/pipeline/pipeline.py
+
+from haystack.core.pipeline import Pipeline as HaystackPipeline
+
+
+class Pipeline(HaystackPipeline):
+	# Any new experimental method that doesn't exist in the original class
+	def run_async(self, inputs) -> Dict[str, Dict[str, Any]]:
+		...
+
+	# Existing methods with breaking changes to their signature, like adding a new mandatory param
+    def to_dict(new_param: str) -> Dict[str, Any]:
+        # do something with the new parameter
+        print(new_param)
+        # call the original method
+        return super().to_dict()
+
+```
+## Documentation
+
+Documentation for `haystack-experimental` can be found [here](https://docs.haystack.deepset.ai/reference/haystack-experimental-api)
+
+
+## Contributing
+
+Direct contributions to `haystack-experimental` are not expected, but Haystack maintainers might ask you to move here
+a pull request that you originally opened on https://github.com/deepset-ai/haystack.


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

Add context to the readme file. [PREVIEW](https://github.com/deepset-ai/haystack-experimental/blob/massi/readme/README.md)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
