### PR TITLE
fix: Wheel paths for builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-unit = 'pytest --cov-report xml:coverage.xml --cov="haystack-experimental" -m "not integration" {args:test}'
+unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration" {args:test}'
 integration = 'pytest --maxfail=5 -m "integration" {args:test}'
 typing = "mypy --install-types --non-interactive {args:haystack_experimental}"
 lint = [
@@ -77,10 +77,10 @@ path = "haystack_experimental/version.py"
 allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
-include = ["/haystack-experimental", "/VERSION.txt"]
+include = ["/haystack_experimental", "/VERSION.txt"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["haystack-experimental"]
+packages = ["haystack_experimental"]
 
 [tool.codespell]
 ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge,ist"


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This was preventing imports of the package.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
