### PR TITLE
adding the OpenAIFunctionCaller

### DIFF
--- a/haystack_experimental/components/__init__.py
+++ b/haystack_experimental/components/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from .tools import OpenAIFunctionCaller
+
+_all_ = [ "OpenAIFunctionCaller"]

--- a/haystack_experimental/components/tools/__init__.py
+++ b/haystack_experimental/components/tools/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/haystack_experimental/components/tools/__init__.py
+++ b/haystack_experimental/components/tools/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from .openai.function_caller import OpenAIFunctionCaller
+
+_all_ = ["OpenAIFunctionCaller"]

--- a/haystack_experimental/components/tools/openai/__init__.py
+++ b/haystack_experimental/components/tools/openai/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/haystack_experimental/components/tools/openai/__init__.py
+++ b/haystack_experimental/components/tools/openai/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from .function_caller import OpenAIFunctionCaller
+
+_all_ = [ "OpenAIFunctionCaller"]

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -3,27 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Any, List, Dict, Callable
+from typing import Any, Callable, Dict, List
 
-from haystack import component, default_from_dict, default_to_dict
+from haystack import component, default_to_dict
 from haystack.dataclasses import ChatMessage
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import deserialize_callable, serialize_callable
 
-_FUNCTION_NAME_FAILURE = "I'm sorry, I tried to run a function that did not exist. Would you like me to correct it and try again?"
+_FUNCTION_NAME_FAILURE = (
+    "I'm sorry, I tried to run a function that did not exist. Would you like me to correct it and try again?"
+)
 _FUNCTION_RUN_FAILURE = "Seems there was an error while runnign the function: {error}"
 
 
 @component
 class OpenAIFunctionCaller:
     """
-    The OpenAIFunctionCaller expects a list of ChatMessages and if there is a tool call with a function name and arguments, it runs the function and returns the
-    result as a ChatMessage from role = 'function'
+    OpenAIFunctionCaller processes a list of chat messages and call Python functions when needed.
+
+    The OpenAIFunctionCaller expects a list of ChatMessages and if there is a tool call with a function name and
+    arguments, it runs the function and returns the result as a ChatMessage from role = 'function'
     """
 
     def __init__(self, available_functions: Dict[str, Callable]):
         """
         Initialize the OpenAIFunctionCaller component.
-        :param available_functions: A dictionary of available functions. This dictionary expects key value pairs of function name, and the function itself. For example, `{"weather_function": weather_function}`
+
+        :param available_functions:
+            A dictionary of available functions. This dictionary expects key value pairs of function name,
+            and the function itself. For example, `{"weather_function": weather_function}`
         """
         self.available_functions = available_functions
 
@@ -37,9 +44,7 @@ class OpenAIFunctionCaller:
         available_function_paths = {}
         for name, function in self.available_functions.items():
             available_function_paths[name] = serialize_callable(function)
-        serialization_dict = default_to_dict(
-            self, available_functions=available_function_paths
-        )
+        serialization_dict = default_to_dict(self, available_functions=available_function_paths)
         return serialization_dict
 
     @classmethod
@@ -55,19 +60,21 @@ class OpenAIFunctionCaller:
         available_function_paths = data.get("init_parameters", {}).get("available_functions")
         available_functions = {}
         for name, path in available_function_paths.items():
-            available_functions[name] =  deserialize_callable(path)
+            available_functions[name] = deserialize_callable(path)
         return cls(available_functions)
 
-    @component.output_types(
-        function_replies=List[ChatMessage], assistant_replies=List[ChatMessage]
-    )
+    @component.output_types(function_replies=List[ChatMessage], assistant_replies=List[ChatMessage])
     def run(self, messages: List[ChatMessage]):
         """
         Evaluates `messages` and invokes available functions if the messages contain tool_calls.
+
         :param messages: A list of messages generated from the `OpenAIChatGenerator`
         :returns: This component returns a list of messages in one of two outputs
-            - `function_replies`: List of ChatMessages containing the result of a function invocation. This message comes from role = 'function'. If the function name was hallucinated or wrong, an assistant message explaining as such is returned
-            - `assistant_replies`: List of ChatMessages containing a regular assistant reply. In this case, there were no tool_calls in the received messages
+            - `function_replies`: List of ChatMessages containing the result of a function invocation.
+                This message comes from role = 'function'. If the function name was hallucinated or wrong,
+                an assistant message explaining as such is returned
+            - `assistant_replies`: List of ChatMessages containing a regular assistant reply. In this case,
+                there were no tool_calls in the received messages
         """
         if messages[0].meta["finish_reason"] == "tool_calls":
             function_calls = json.loads(messages[0].content)
@@ -85,11 +92,7 @@ class OpenAIFunctionCaller:
                             )
                         )
                     except BaseException as e:
-                        messages.append(
-                            ChatMessage.from_assistant(
-                                _FUNCTION_RUN_FAILURE.format(error=e)
-                            )
-                        )
+                        messages.append(ChatMessage.from_assistant(_FUNCTION_RUN_FAILURE.format(error=e)))
                 else:
                     messages.append(ChatMessage.from_assistant(_FUNCTION_NAME_FAILURE))
             return {"function_replies": messages}

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -16,7 +16,7 @@ class OpenAIFunctionCaller:
     result as a ChatMessage from role = 'function'
     """
 
-    def __init__(self, available_functions):
+    def __init__(self, available_functions: Dict[str, Callable[...]):
         """
         Initialize the OpenAIFunctionCaller component.
         :param available_functions: A dictionary of available functions. This dictionary expects key value pairs of function name, and the function itslelf. For example {"weather_function": weather_function}

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -91,7 +91,7 @@ class OpenAIFunctionCaller:
                                 name=function_name,
                             )
                         )
-                    except BaseException as e:
+                    except Exception as e:
                         messages.append(ChatMessage.from_assistant(_FUNCTION_RUN_FAILURE.format(error=e)))
                 else:
                     messages.append(ChatMessage.from_assistant(_FUNCTION_NAME_FAILURE))

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -38,7 +38,7 @@ class OpenAIFunctionCaller:
         for name, function in self.available_functions.items():
             available_function_paths[name] = serialize_callable(function)
         serialization_dict = default_to_dict(
-            self, available_functions=available_function_callbacks
+            self, available_functions=available_function_paths
         )
         return serialization_dict
 
@@ -56,8 +56,7 @@ class OpenAIFunctionCaller:
         available_functions = {}
         for name, path in available_function_paths.items():
             available_functions[name] =  deserialize_callable(path)
-
-        return default_from_dict(cls, available_functions)
+        return cls(available_functions)
 
     @component.output_types(
         function_replies=List[ChatMessage], assistant_replies=List[ChatMessage]

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -61,7 +61,7 @@ class OpenAIFunctionCaller:
         for name, path in available_function_paths.items():
             available_functions[name] =  deserialize_callable(path)
 
-        return default_from_dict(cls, data)
+        return default_from_dict(cls, available_functions)
 
     @component.output_types(
         function_replies=List[ChatMessage], assistant_replies=List[ChatMessage]

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -92,6 +92,7 @@ class OpenAIFunctionCaller:
                                 name=function_name,
                             )
                         )
+                    # pylint: disable=broad-exception-caught
                     except Exception as e:
                         messages.append(ChatMessage.from_assistant(_FUNCTION_RUN_FAILURE.format(error=e)))
                 else:

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -19,7 +19,7 @@ class OpenAIFunctionCaller:
     def __init__(self, available_functions: Dict[str, Callable[...]):
         """
         Initialize the OpenAIFunctionCaller component.
-        :param available_functions: A dictionary of available functions. This dictionary expects key value pairs of function name, and the function itslelf. For example {"weather_function": weather_function}
+        :param available_functions: A dictionary of available functions. This dictionary expects key value pairs of function name, and the function itself. For example, `{"weather_function": weather_function}`
         """
         self.available_functions = available_functions
 

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -12,7 +12,7 @@ from haystack.utils import deserialize_callable, serialize_callable
 _FUNCTION_NAME_FAILURE = (
     "I'm sorry, I tried to run a function that did not exist. Would you like me to correct it and try again?"
 )
-_FUNCTION_RUN_FAILURE = "Seems there was an error while runnign the function: {error}"
+_FUNCTION_RUN_FAILURE = "Seems there was an error while running the function: {error}"
 
 
 @component

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -34,13 +34,9 @@ class OpenAIFunctionCaller:
         :returns:
             Dictionary with serialized data.
         """
-        available_function_callbacks = {}
-        for function in self.available_functions:
-            available_function_callbacks[function] = (
-                serialize_callable(self.available_functions[function])
-                if function
-                else None
-            )
+        available_function_paths = {}
+        for name, function in self.available_functions.items():
+            available_function_paths[name] = serialize_callable(function)
         serialization_dict = default_to_dict(
             self, available_functions=available_function_callbacks
         )

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -5,7 +5,7 @@
 import json
 from typing import Any, Callable, Dict, List
 
-from haystack import component, default_to_dict
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_callable, serialize_callable
 
@@ -62,7 +62,7 @@ class OpenAIFunctionCaller:
         for name, path in available_function_paths.items():
             available_functions[name] = deserialize_callable(path)
         data["init_parameters"]["available_functions"] = available_functions
-        return default_to_dict(cls, data)
+        return default_from_dict(cls, data)
 
     @component.output_types(function_replies=List[ChatMessage], assistant_replies=List[ChatMessage])
     def run(self, messages: List[ChatMessage]):

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import List
+
+from haystack import component
+from haystack.dataclasses import ChatMessage
+
+
+@component
+class OpenAIFunctionCaller:
+    """
+    The OpenAIFunctionCaller expects a list of ChatMessages and if there is a tool call with a function name and arguments, it runs the function and returns the
+    result as a ChatMessage from role = 'function'
+    """
+
+    def __init__(self, available_functions):
+        """
+        Initialize the OpenAIFunctionCaller component.
+        :param available_functions: A dictionary of available functions. This dictionary expects key value pairs of function name, and the function itslelf. For example {"weather_function": weather_function}
+        """
+        self.available_functions = available_functions
+
+    @component.output_types(
+        function_replies=List[ChatMessage], assistant_replies=List[ChatMessage]
+    )
+    def run(self, messages: List[ChatMessage]):
+        """
+        Evaluates `messages` and invokes available functions if the messages contain tool_calls.
+        :param messages: A list of messages generated from the `OpenAIChatGenerator`
+        :returns: This component returns a list of messages in one of two outputs
+            - `function_replies`: List of ChatMessages containing the result of a function invocation. This message comes from role = 'function'. If the function name was hallucinated or wrong, an assistant message explaining as such is returned
+            - `assistant_replies`: List of ChatMessages containing a regular assistant reply. In this case, there were no tool_calls in the received messages
+        """
+        if messages[0].meta["finish_reason"] == "tool_calls":
+            function_calls = json.loads(messages[0].content)
+            for function_call in function_calls:
+                function_name = function_call["function"]["name"]
+                function_args = json.loads(function_call["function"]["arguments"])
+                if function_name in self.available_functions:
+                    function_to_call = self.available_functions[function_name]
+                    function_response = function_to_call(**function_args)
+                    messages.append(
+                        ChatMessage.from_function(
+                            content=json.dumps(function_response), name=function_name
+                        )
+                    )
+                else:
+                    messages.append(
+                        ChatMessage.from_assistant(
+                            """I'm sorry, I tried to run a function that did not exist. 
+                                                        Would you like me to correct it and try again?"""
+                        )
+                    )
+            return {"function_replies": messages}
+        else:
+            return {"assistant_replies": messages}

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -56,14 +56,10 @@ class OpenAIFunctionCaller:
         :returns:
             The deserialized component.
         """
-        init_params = data.get("init_parameters", {})
-        available_function_callback_handler = init_params.get("available_functions")
-        if available_function_callback_handler:
-            for callback in data["init_parameters"]["available_functions"]:
-                print(callback)
-                deserialize_callable(
-                    data["init_parameters"]["available_functions"][callback]
-                )
+        available_function_paths = data.get("init_parameters", {}).get("available_functions")
+        available_functions = {}
+        for name, path in available_function_paths.items():
+            available_functions[name] =  deserialize_callable(path)
 
         return default_from_dict(cls, data)
 

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -55,5 +55,4 @@ class OpenAIFunctionCaller:
                         )
                     )
             return {"function_replies": messages}
-        else:
-            return {"assistant_replies": messages}
+        return {"assistant_replies": messages}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-unit = 'pytest --cov-report xml:coverage.xml --cov="haystack-experimental" -m "not integration" {args:test}'
+unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration" {args:test}'
 integration = 'pytest --maxfail=5 -m "integration" {args:test}'
 typing = "mypy --install-types --non-interactive {args:haystack_experimental}"
 lint = [
@@ -77,10 +77,10 @@ path = "haystack_experimental/version.py"
 allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
-include = ["/haystack-experimental", "/VERSION.txt"]
+include = ["/haystack_experimental", "/VERSION.txt"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["haystack-experimental"]
+packages = ["haystack_experimental"]
 
 [tool.codespell]
 ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge,ist"

--- a/test/components/__init__.py
+++ b/test/components/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/components/tools/__init__.py
+++ b/test/components/tools/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/components/tools/openai/__init__.py
+++ b/test/components/tools/openai/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/components/tools/openai/test_function_caller.py
+++ b/test/components/tools/openai/test_function_caller.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+import json
+import pytest
+
+# from haystack.utils import Secret
+from haystack_experimental.components.tools import OpenAIFunctionCaller
+from haystack.dataclasses import ChatMessage
+
+WEATHER_INFO = {
+    "Berlin": {"weather": "mostly sunny", "temperature": 7, "unit": "celsius"},
+    "Paris": {"weather": "mostly cloudy", "temperature": 8, "unit": "celsius"},
+    "Rome": {"weather": "sunny", "temperature": 14, "unit": "celsius"},
+    "Madrid": {"weather": "sunny", "temperature": 10, "unit": "celsius"},
+    "London": {"weather": "cloudy", "temperature": 9, "unit": "celsius"},
+}
+
+
+def mock_weather_func(location):
+    if location in WEATHER_INFO:
+        return WEATHER_INFO[location]
+    else:
+        return {"weather": "sunny", "temperature": 21.8, "unit": "fahrenheit"}
+
+class TestOpenAIFunctionCaller:
+
+    def test_init(self, monkeypatch):
+        component = OpenAIFunctionCaller(available_functions = {"mock_weather_func": mock_weather_func})
+        assert component.available_functions == {"mock_weather_func": mock_weather_func}
+
+    def test_successful_function_call(self, monkeypatch):
+        component = OpenAIFunctionCaller(available_functions = {"mock_weather_func": mock_weather_func})
+        mock_assistant_message = ChatMessage.from_assistant(content='[{"id": "mock-id", "function": {"arguments": "{\\"location\\":\\"Berlin\\"}", "name": "mock_weather_func"}, "type": "function"}]',
+                                                                meta={"finish_reason": "tool_calls"})
+        result = component.run(messages=[mock_assistant_message])
+        result_obj = json.loads(result["function_replies"][-1].content)
+        assert result_obj['weather'] == WEATHER_INFO['Berlin']['weather']
+        assert result_obj['temperature'] == WEATHER_INFO['Berlin']['temperature']
+        assert result_obj['unit'] == WEATHER_INFO['Berlin']['unit']
+
+    
+    def test_failing_function_call(self, monkeypatch):
+        component = OpenAIFunctionCaller(available_functions = {"mock_weather_func": mock_weather_func})
+        mock_assistant_message = ChatMessage.from_assistant(content='[{"id": "mock-id", "function": {"arguments": "{\\"location\\":\\"Berlin\\"}", "name": "mock_weather"}, "type": "function"}]',
+                                                                meta={"finish_reason": "tool_calls"})
+        result = component.run(messages=[mock_assistant_message])
+        assert result["function_replies"][-1].content == "I'm sorry, I tried to run a function that did not exist. Would you like me to correct it and try again?"
+    
+    def test_to_dict(self, monkeypatch):
+        component = OpenAIFunctionCaller(available_functions = {"mock_weather_func": mock_weather_func})
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack_experimental.components.tools.openai.function_caller.OpenAIFunctionCaller",
+            "init_parameters": {
+                "available_functions": {'mock_weather_func': 'test.components.tools.openai.test_function_caller.mock_weather_func'}
+            },
+        }
+    
+    def test_from_dict(self, monkeypatch):
+        data = {
+            "type": "haystack_experimental.components.tools.openai.function_caller.OpenAIFunctionCaller",
+            "init_parameters": {
+                "available_functions": {'mock_weather_func': 'test.components.tools.openai.test_function_caller.mock_weather_func'},
+            },
+        }
+        component: OpenAIFunctionCaller = OpenAIFunctionCaller.from_dict(data)
+        assert component.available_functions == {'mock_weather_func': mock_weather_func}


### PR DESCRIPTION
### Proposed Changes:

 I propose adding this `OpenAIFunctionCaller` component that is able to accept a list of ChatMessages, and run a function if there were any `tool_calls` within these messages. 

Some simple guardrails that have been added: 
If the tool/function name in the message that we get doesn't actually exist (hallucinated) , the component returns an assistant message indicating as such. 

### How did you test it?

Manual tests. Here is the pipeline I'm using:
```
message_collector = BranchJoiner(List[ChatMessage])
chat_generator = OpenAIChatGenerator(model="gpt-3.5-turbo", generation_kwargs={'tools': tools})
function_caller = OpenAIFunctionCaller(available_functions={"rag_pipeline_func": rag_pipeline_func, 
                                                            "get_current_weather": get_current_weather})

function_calling_pipeline = Pipeline()
function_calling_pipeline.add_component("message_collector", message_collector)
function_calling_pipeline.add_component("generator", chat_generator)
function_calling_pipeline.add_component("function_caller", function_caller)

function_calling_pipeline.connect("message_collector", "generator.messages")
function_calling_pipeline.connect("generator", "function_caller")
function_calling_pipeline.connect("function_caller.function_replies", "message_collector")

messages = [
    ChatMessage.from_system(
        """If needed, break down the users question to simpler questions and follow up questions that you can use with your tools.
        Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous."""
    )
]
while True:
  user_input = input("INFO: Type 'exit' or 'quit' to stop\n")
  if user_input.lower() == "exit" or user_input.lower() == "quit":
    break
  messages.append(ChatMessage.from_user(user_input))
  response = function_calling_pipeline.run({"message_collector": {"value": messages}})
  messages.extend(response['function_caller']['assistant_replies'])
  print(response['function_caller']['assistant_replies'][0])

```

### Notes for the reviewer

You can try this pipeline [here](https://colab.research.google.com/drive/1Gk4H5Vy4LoEJJc-vEwpllqQd03ZJE_sX?usp=sharing)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
