### PR TITLE
feat: Add `ContextRelevanceEvaluator` to RAG eval harness

### DIFF
--- a/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
+++ b/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
@@ -7,6 +7,7 @@ from typing import Set
 
 from haystack import Pipeline
 from haystack.components.evaluators import (
+    ContextRelevanceEvaluator,
     DocumentMAPEvaluator,
     DocumentMRREvaluator,
     DocumentRecallEvaluator,
@@ -34,12 +35,17 @@ def default_rag_evaluation_pipeline(
     metric_ctors = {
         RAGEvaluationMetric.DOCUMENT_MAP: DocumentMAPEvaluator,
         RAGEvaluationMetric.DOCUMENT_MRR: DocumentMRREvaluator,
-        RAGEvaluationMetric.DOCUMENT_RECALL_SINGLE_HIT: partial(DocumentRecallEvaluator, mode=RecallMode.SINGLE_HIT),
-        RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT: partial(DocumentRecallEvaluator, mode=RecallMode.MULTI_HIT),
+        RAGEvaluationMetric.DOCUMENT_RECALL_SINGLE_HIT: partial(
+            DocumentRecallEvaluator, mode=RecallMode.SINGLE_HIT
+        ),
+        RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT: partial(
+            DocumentRecallEvaluator, mode=RecallMode.MULTI_HIT
+        ),
         RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY: partial(
             SASEvaluator, model="sentence-transformers/all-MiniLM-L6-v2"
         ),
         RAGEvaluationMetric.ANSWER_FAITHFULNESS: FaithfulnessEvaluator,
+        RAGEvaluationMetric.CONTEXT_RELEVANCE: ContextRelevanceEvaluator,
     }
 
     for metric in metrics:

--- a/haystack_experimental/evaluation/harness/rag/harness.py
+++ b/haystack_experimental/evaluation/harness/rag/harness.py
@@ -266,6 +266,12 @@ class RAGEvaluationHarness(
                     "replies",
                 ),
             },
+            RAGEvaluationMetric.CONTEXT_RELEVANCE: {
+                "contexts": (
+                    RAGExpectedComponent.DOCUMENT_RETRIEVER,
+                    "retrieved_documents",
+                ),
+            },
         }
 
         outputs_to_inputs: Dict[str, List[str]] = {}
@@ -344,6 +350,11 @@ class RAGEvaluationHarness(
                 eval_inputs[metric.value] = {
                     "ground_truth_documents": inputs.ground_truth_documents
                 }
+            elif metric in (
+                RAGEvaluationMetric.ANSWER_FAITHFULNESS,
+                RAGEvaluationMetric.CONTEXT_RELEVANCE,
+            ):
+                eval_inputs[metric.value] = {"questions": inputs.queries}
             elif metric == RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY:
                 if inputs.ground_truth_answers is None:
                     raise ValueError(
@@ -357,8 +368,6 @@ class RAGEvaluationHarness(
                 eval_inputs[metric.value] = {
                     "ground_truth_answers": inputs.ground_truth_answers
                 }
-            elif metric == RAGEvaluationMetric.ANSWER_FAITHFULNESS:
-                eval_inputs[metric.value] = {"questions": inputs.queries}
 
         return eval_inputs
 

--- a/haystack_experimental/evaluation/harness/rag/parameters.py
+++ b/haystack_experimental/evaluation/harness/rag/parameters.py
@@ -74,6 +74,9 @@ class RAGEvaluationMetric(Enum):
     #: Answer Faithfulness.
     ANSWER_FAITHFULNESS = "metric_answer_faithfulness"
 
+    #: Context Relevance.
+    CONTEXT_RELEVANCE = "metric_context_relevance"
+
 
 @dataclass(frozen=True)
 class RAGEvaluationInput:

--- a/test/evaluation/harness/rag/test_harness.py
+++ b/test/evaluation/harness/rag/test_harness.py
@@ -4,7 +4,6 @@
 from typing import Any, Dict, List, Optional
 import pytest
 
-import random
 from haystack_experimental.evaluation.harness.rag import (
     RAGEvaluationHarness,
     RAGExpectedComponent,
@@ -17,6 +16,11 @@ from haystack import Pipeline, component, Document, default_to_dict, default_fro
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.embedders import SentenceTransformersTextEmbedder
 from haystack.components.builders import PromptBuilder
+from haystack.components.evaluators import (
+    ContextRelevanceEvaluator,
+    FaithfulnessEvaluator,
+    SASEvaluator,
+)
 from haystack.components.retrievers.in_memory import (
     InMemoryEmbeddingRetriever,
     InMemoryBM25Retriever,
@@ -93,6 +97,51 @@ class MockKeywordRetriever:
         self.counter += 1
 
         return {"documents": samples[idx]}
+
+
+@component
+class MockModelBasedEvaluator:
+    def __init__(self, metric: RAGEvaluationMetric) -> None:
+        self.metric = metric
+
+        io_map = {
+            RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY: SASEvaluator(
+                "sentence-transformers/all-MiniLM-L6-v2"
+            ),
+            RAGEvaluationMetric.ANSWER_FAITHFULNESS: FaithfulnessEvaluator(
+                api_key=Secret.from_token("test_key")
+            ),
+            RAGEvaluationMetric.CONTEXT_RELEVANCE: ContextRelevanceEvaluator(
+                api_key=Secret.from_token("test_key")
+            ),
+        }
+
+        self.__haystack_input__ = io_map[metric].__haystack_input__
+        self.__haystack_output__ = io_map[metric].__haystack_output__
+
+    @staticmethod
+    def default_output(metric) -> Dict[str, Any]:
+        if metric == RAGEvaluationMetric.ANSWER_FAITHFULNESS:
+            return {
+                "individual_scores": [1] * 6,
+                "score": 1.0,
+            }
+        else:
+            return {
+                "individual_scores": [1] * 6,
+                "score": 1.0,
+                "results": [
+                    {
+                        "statements": ["placeholder"],
+                        "statement_scores": [1.0],
+                        "score": 1.0,
+                    }
+                ]
+                * 6,
+            }
+
+    def run(self, **kwargs) -> Dict[str, Any]:
+        return self.default_output(self.metric)
 
 
 def build_rag_pipeline_with_query_embedder(
@@ -202,55 +251,13 @@ def rag_pipeline_with_keyword_retriever():
     return build_rag_pipeline_with_keyword_retriever(generator_name="generator")
 
 
-def test_rag_eval_harness_init(rag_pipeline):
-    harness = RAGEvaluationHarness(
-        rag_pipeline,
-        rag_components={
-            RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
-                name="text_embedder", input_mapping={"query": "text"}
-            ),
-            RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
-                name="retriever", output_mapping={"retrieved_documents": "documents"}
-            ),
-            RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
-                name="llm", output_mapping={"replies": "replies"}
-            ),
-        },
-        metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-    )
-
-
-def test_rag_eval_harness_init_invalid_expected_component(
-    rag_pipeline,
-):
-    with pytest.raises(ValueError, match="RAG evaluation harness requires metadata"):
-        _ = RAGEvaluationHarness(
-            rag_pipeline,
-            rag_components={},
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-        )
-
-    with pytest.raises(ValueError, match="RAG evaluation harness requires metadata"):
-        _ = RAGEvaluationHarness(
+class TestRAGEvaluationHarness:
+    def test_init(self, rag_pipeline):
+        harness = RAGEvaluationHarness(
             rag_pipeline,
             rag_components={
                 RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
                     name="text_embedder", input_mapping={"query": "text"}
-                ),
-            },
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-        )
-
-
-def test_rag_eval_harness_init_invalid_missing_components(
-    rag_pipeline,
-):
-    with pytest.raises(ValueError, match="named 'embedder' not found in pipeline"):
-        _ = RAGEvaluationHarness(
-            rag_pipeline,
-            rag_components={
-                RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
-                    name="embedder", input_mapping={"query": "text"}
                 ),
                 RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
                     name="retriever",
@@ -263,298 +270,408 @@ def test_rag_eval_harness_init_invalid_missing_components(
             metrics={RAGEvaluationMetric.DOCUMENT_MAP},
         )
 
+    def test_init_invalid_expected_component(self, rag_pipeline):
+        with pytest.raises(
+            ValueError, match="RAG evaluation harness requires metadata"
+        ):
+            _ = RAGEvaluationHarness(
+                rag_pipeline,
+                rag_components={},
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
-def test_rag_eval_harness_init_invalid_missing_inputs(rag_pipeline):
-    with pytest.raises(
-        ValueError,
-        match="Required input 'rando_input' not found in 'query_processor' component named 'text_embedder'",
-    ):
-        _ = RAGEvaluationHarness(
-            rag_pipeline,
-            rag_components={
-                RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
-                    name="text_embedder", input_mapping={"query": "rando_input"}
-                ),
-                RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
-                    name="retriever",
-                    output_mapping={"retrieved_documents": "documents"},
-                ),
-                RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
-                    name="llm", output_mapping={"replies": "replies"}
-                ),
-            },
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-        )
+        with pytest.raises(
+            ValueError, match="RAG evaluation harness requires metadata"
+        ):
+            _ = RAGEvaluationHarness(
+                rag_pipeline,
+                rag_components={
+                    RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
+                        name="text_embedder", input_mapping={"query": "text"}
+                    ),
+                },
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
+    def test_init_invalid_missing_components(self, rag_pipeline):
+        with pytest.raises(ValueError, match="named 'embedder' not found in pipeline"):
+            _ = RAGEvaluationHarness(
+                rag_pipeline,
+                rag_components={
+                    RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
+                        name="embedder", input_mapping={"query": "text"}
+                    ),
+                    RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
+                        name="retriever",
+                        output_mapping={"retrieved_documents": "documents"},
+                    ),
+                    RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
+                        name="llm", output_mapping={"replies": "replies"}
+                    ),
+                },
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
-def test_rag_eval_harness_init_invalid_missing_outputs(
-    rag_pipeline,
-):
-    with pytest.raises(
-        ValueError,
-        match="Required output 'rando_output' not found in 'response_generator' component named 'llm'",
-    ):
-        _ = RAGEvaluationHarness(
-            rag_pipeline,
-            rag_components={
-                RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
-                    name="text_embedder", input_mapping={"query": "text"}
-                ),
-                RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
-                    name="retriever",
-                    output_mapping={"retrieved_documents": "documents"},
-                ),
-                RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
-                    name="llm", output_mapping={"replies": "rando_output"}
-                ),
-            },
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-        )
+    def test_init_invalid_missing_inputs(self, rag_pipeline):
+        with pytest.raises(
+            ValueError,
+            match="Required input 'rando_input' not found in 'query_processor' component named 'text_embedder'",
+        ):
+            _ = RAGEvaluationHarness(
+                rag_pipeline,
+                rag_components={
+                    RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
+                        name="text_embedder", input_mapping={"query": "rando_input"}
+                    ),
+                    RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
+                        name="retriever",
+                        output_mapping={"retrieved_documents": "documents"},
+                    ),
+                    RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
+                        name="llm", output_mapping={"replies": "replies"}
+                    ),
+                },
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
+    def test_init_invalid_missing_outputs(self, rag_pipeline):
+        with pytest.raises(
+            ValueError,
+            match="Required output 'rando_output' not found in 'response_generator' component named 'llm'",
+        ):
+            _ = RAGEvaluationHarness(
+                rag_pipeline,
+                rag_components={
+                    RAGExpectedComponent.QUERY_PROCESSOR: RAGExpectedComponentMetadata(
+                        name="text_embedder", input_mapping={"query": "text"}
+                    ),
+                    RAGExpectedComponent.DOCUMENT_RETRIEVER: RAGExpectedComponentMetadata(
+                        name="retriever",
+                        output_mapping={"retrieved_documents": "documents"},
+                    ),
+                    RAGExpectedComponent.RESPONSE_GENERATOR: RAGExpectedComponentMetadata(
+                        name="llm", output_mapping={"replies": "rando_output"}
+                    ),
+                },
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
-def test_rag_eval_harness_init_defaults(
-    rag_pipeline_with_query_embedder, rag_pipeline_with_keyword_retriever
-):
-    _ = RAGEvaluationHarness.default_with_embedding_retriever(
-        rag_pipeline_with_query_embedder, metrics={RAGEvaluationMetric.DOCUMENT_MAP}
-    )
-
-    _ = RAGEvaluationHarness.default_with_keyword_retriever(
-        rag_pipeline_with_keyword_retriever, metrics={RAGEvaluationMetric.DOCUMENT_MAP}
-    )
-
-
-def test_rag_eval_harness_init_defaults_invalid_missing_inputs():
-    with pytest.raises(
-        ValueError,
-        match="Required input 'text' not found in 'query_processor' component named 'query_embedder'",
+    def test_init_defaults(
+        self, rag_pipeline_with_query_embedder, rag_pipeline_with_keyword_retriever
     ):
         _ = RAGEvaluationHarness.default_with_embedding_retriever(
-            build_rag_pipeline_with_query_embedder(
-                embedder_name="llm", generator_name="query_embedder"
-            ),
+            rag_pipeline_with_query_embedder, metrics={RAGEvaluationMetric.DOCUMENT_MAP}
+        )
+
+        _ = RAGEvaluationHarness.default_with_keyword_retriever(
+            rag_pipeline_with_keyword_retriever,
             metrics={RAGEvaluationMetric.DOCUMENT_MAP},
         )
 
-    with pytest.raises(
-        ValueError,
-        match="Required input 'query' not found in 'query_processor' component named 'retriever'",
+    def test_init_defaults_invalid_missing_inputs(
+        self,
     ):
-        _ = RAGEvaluationHarness.default_with_keyword_retriever(
+        with pytest.raises(
+            ValueError,
+            match="Required input 'text' not found in 'query_processor' component named 'query_embedder'",
+        ):
+            _ = RAGEvaluationHarness.default_with_embedding_retriever(
+                build_rag_pipeline_with_query_embedder(
+                    embedder_name="llm", generator_name="query_embedder"
+                ),
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="Required input 'query' not found in 'query_processor' component named 'retriever'",
+        ):
+            _ = RAGEvaluationHarness.default_with_keyword_retriever(
+                build_rag_pipeline_with_keyword_retriever(
+                    retriever_name="llm", generator_name="retriever"
+                ),
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
+
+    def test_init_defaults_invalid_missing_outputs(self):
+        non_conformant_query_embedder_pipeline = build_rag_pipeline_with_query_embedder(
+            embedder_name="query_embedder",
+            generator_name="generator",
+            generator_component=NonConformantComponent(
+                {"prompt": str}, {"responses": List[str]}
+            ),
+        )
+        non_conformant_keyword_retriever_pipeline = (
             build_rag_pipeline_with_keyword_retriever(
-                retriever_name="llm", generator_name="retriever"
-            ),
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+                retriever_component=NonConformantComponent(
+                    {"query": str}, {"docs": List[Document]}
+                ),
+                retriever_output_name="docs",
+            )
         )
 
+        with pytest.raises(
+            ValueError,
+            match="Required output 'replies' not found in 'response_generator' component named 'generator'",
+        ):
+            _ = RAGEvaluationHarness.default_with_embedding_retriever(
+                non_conformant_query_embedder_pipeline,
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
 
-def test_rag_eval_harness_init_defaults_invalid_missing_outputs():
-    non_conformant_query_embedder_pipeline = build_rag_pipeline_with_query_embedder(
-        embedder_name="query_embedder",
-        generator_name="generator",
-        generator_component=NonConformantComponent(
-            {"prompt": str}, {"responses": List[str]}
-        ),
-    )
-    non_conformant_keyword_retriever_pipeline = (
-        build_rag_pipeline_with_keyword_retriever(
-            retriever_component=NonConformantComponent(
-                {"query": str}, {"docs": List[Document]}
-            ),
-            retriever_output_name="docs",
+        with pytest.raises(
+            ValueError,
+            match="Required output 'documents' not found in 'document_retriever' component named 'retriever'",
+        ):
+            _ = RAGEvaluationHarness.default_with_keyword_retriever(
+                non_conformant_keyword_retriever_pipeline,
+                metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+            )
+
+    def test_run_invalid_ground_truths(self, rag_pipeline_with_query_embedder):
+        harness_map = RAGEvaluationHarness.default_with_embedding_retriever(
+            rag_pipeline_with_query_embedder,
+            metrics={
+                RAGEvaluationMetric.DOCUMENT_MAP,
+            },
         )
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="Required output 'replies' not found in 'response_generator' component named 'generator'",
-    ):
-        _ = RAGEvaluationHarness.default_with_embedding_retriever(
-            non_conformant_query_embedder_pipeline,
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="Required output 'documents' not found in 'document_retriever' component named 'retriever'",
-    ):
-        _ = RAGEvaluationHarness.default_with_keyword_retriever(
-            non_conformant_keyword_retriever_pipeline,
-            metrics={RAGEvaluationMetric.DOCUMENT_MAP},
+        harness_sas = RAGEvaluationHarness.default_with_embedding_retriever(
+            rag_pipeline_with_query_embedder,
+            metrics={
+                RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY,
+            },
         )
 
+        input_no_gt_docs = RAGEvaluationInput(
+            queries=["What is the capital of France?"]
+        )
+        input_mismatching_gt_docs = RAGEvaluationInput(
+            queries=["What is the capital of France?"], ground_truth_documents=[]
+        )
+        input_no_gt_answers = RAGEvaluationInput(
+            queries=["What is the capital of France?"],
+            ground_truth_documents=[
+                [Document(content="Paris is the capital of France.")]
+            ],
+        )
+        input_mismatching_gt_answers = RAGEvaluationInput(
+            queries=["What is the capital of France?"],
+            ground_truth_documents=[
+                [Document(content="Paris is the capital of France.")]
+            ],
+            ground_truth_answers=[],
+        )
 
-def test_rag_eval_harness_run_invalid_ground_truths(rag_pipeline_with_query_embedder):
-    harness_map = RAGEvaluationHarness.default_with_embedding_retriever(
+        with pytest.raises(ValueError, match="Ground truth documents required"):
+            _ = harness_map.run(input_no_gt_docs)
+
+        with pytest.raises(
+            ValueError,
+            match="Length of ground truth documents should match the number of queries",
+        ):
+            _ = harness_map.run(input_mismatching_gt_docs)
+
+        with pytest.raises(ValueError, match="Ground truth answers required"):
+            _ = harness_sas.run(input_no_gt_answers)
+
+        with pytest.raises(
+            ValueError,
+            match="Length of ground truth answers should match the number of queries",
+        ):
+            _ = harness_sas.run(input_mismatching_gt_answers)
+
+    def test_run_invalid_additional_input(
+        self,
         rag_pipeline_with_query_embedder,
-        metrics={
-            RAGEvaluationMetric.DOCUMENT_MAP,
-        },
-    )
-    harness_sas = RAGEvaluationHarness.default_with_embedding_retriever(
-        rag_pipeline_with_query_embedder,
-        metrics={
-            RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY,
-        },
-    )
-
-    input_no_gt_docs = RAGEvaluationInput(queries=["What is the capital of France?"])
-    input_mismatching_gt_docs = RAGEvaluationInput(
-        queries=["What is the capital of France?"], ground_truth_documents=[]
-    )
-    input_no_gt_answers = RAGEvaluationInput(
-        queries=["What is the capital of France?"],
-        ground_truth_documents=[[Document(content="Paris is the capital of France.")]],
-    )
-    input_mismatching_gt_answers = RAGEvaluationInput(
-        queries=["What is the capital of France?"],
-        ground_truth_documents=[[Document(content="Paris is the capital of France.")]],
-        ground_truth_answers=[],
-    )
-
-    with pytest.raises(ValueError, match="Ground truth documents required"):
-        _ = harness_map.run(input_no_gt_docs)
-
-    with pytest.raises(
-        ValueError,
-        match="Length of ground truth documents should match the number of queries",
     ):
-        _ = harness_map.run(input_mismatching_gt_docs)
-
-    with pytest.raises(ValueError, match="Ground truth answers required"):
-        _ = harness_sas.run(input_no_gt_answers)
-
-    with pytest.raises(
-        ValueError,
-        match="Length of ground truth answers should match the number of queries",
-    ):
-        _ = harness_sas.run(input_mismatching_gt_answers)
-
-
-def test_rag_eval_harness_run_invalid_additional_input(
-    rag_pipeline_with_query_embedder,
-):
-    harness = RAGEvaluationHarness.default_with_embedding_retriever(
-        rag_pipeline_with_query_embedder,
-        metrics={
-            RAGEvaluationMetric.DOCUMENT_MAP,
-        },
-    )
-
-    input = RAGEvaluationInput(
-        queries=["What is the capital of France?"],
-        ground_truth_documents=[[Document(content="Paris is the capital of France.")]],
-        additional_rag_inputs={"query_embedder": {"text": ["Some other question?"]}},
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="Query embedder input 'text' cannot be provided as additional input",
-    ):
-        _ = harness.run(input)
-
-
-def test_rag_eval_harness_run_invalid_override(
-    rag_pipeline_with_query_embedder,
-):
-    harness = RAGEvaluationHarness.default_with_embedding_retriever(
-        rag_pipeline_with_query_embedder,
-        metrics={
-            RAGEvaluationMetric.DOCUMENT_MAP,
-        },
-    )
-
-    input = RAGEvaluationInput(
-        queries=["What is the capital of France?"],
-        ground_truth_documents=[[Document(content="Paris is the capital of France.")]],
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="Cannot override non-existent component 'rando_component'",
-    ):
-        _ = harness.run(
-            input,
-            overrides=RAGEvaluationOverrides(
-                rag_pipeline={"rando_component": {"Some": "thing"}}
-            ),
+        harness = RAGEvaluationHarness.default_with_embedding_retriever(
+            rag_pipeline_with_query_embedder,
+            metrics={
+                RAGEvaluationMetric.DOCUMENT_MAP,
+            },
         )
 
-    with pytest.raises(
-        ValueError,
-        match="Cannot override parameters of unused evaluation metric",
+        input = RAGEvaluationInput(
+            queries=["What is the capital of France?"],
+            ground_truth_documents=[
+                [Document(content="Paris is the capital of France.")]
+            ],
+            additional_rag_inputs={
+                "query_embedder": {"text": ["Some other question?"]}
+            },
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Query embedder input 'text' cannot be provided as additional input",
+        ):
+            _ = harness.run(input)
+
+    def test_run_invalid_override(
+        self,
+        rag_pipeline_with_query_embedder,
     ):
-        _ = harness.run(
-            input,
-            overrides=RAGEvaluationOverrides(
-                eval_pipeline={
-                    RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT: {
-                        "mode": "single_hit"
+        harness = RAGEvaluationHarness.default_with_embedding_retriever(
+            rag_pipeline_with_query_embedder,
+            metrics={
+                RAGEvaluationMetric.DOCUMENT_MAP,
+            },
+        )
+
+        input = RAGEvaluationInput(
+            queries=["What is the capital of France?"],
+            ground_truth_documents=[
+                [Document(content="Paris is the capital of France.")]
+            ],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot override non-existent component 'rando_component'",
+        ):
+            _ = harness.run(
+                input,
+                overrides=RAGEvaluationOverrides(
+                    rag_pipeline={"rando_component": {"Some": "thing"}}
+                ),
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot override parameters of unused evaluation metric",
+        ):
+            _ = harness.run(
+                input,
+                overrides=RAGEvaluationOverrides(
+                    eval_pipeline={
+                        RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT: {
+                            "mode": "single_hit"
+                        }
                     }
+                ),
+            )
+
+    def test_run_statistical_metrics(self):
+        harness = RAGEvaluationHarness.default_with_keyword_retriever(
+            build_rag_pipeline_with_keyword_retriever(
+                retriever_component=MockKeywordRetriever(),
+                generator_component=MockGenerator(arg=0),
+                generator_name="generator",
+            ),
+            metrics={
+                RAGEvaluationMetric.DOCUMENT_MAP,
+                RAGEvaluationMetric.DOCUMENT_MRR,
+                RAGEvaluationMetric.DOCUMENT_RECALL_SINGLE_HIT,
+                RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT,
+            },
+        )
+
+        inputs = RAGEvaluationInput(
+            queries=["What is the capital of France?"] * 6,
+            ground_truth_documents=[
+                [Document(content="France")],
+                [Document(content="9th century"), Document(content="9th")],
+                [Document(content="classical music"), Document(content="classical")],
+                [Document(content="11th century"), Document(content="the 11th")],
+                [Document(content="Denmark, Iceland and Norway")],
+                [Document(content="10th century"), Document(content="10th")],
+            ],
+        )
+
+        output = harness.run(
+            inputs,
+            overrides=RAGEvaluationOverrides(
+                rag_pipeline={
+                    "generator": {"arg": 100},
                 }
             ),
+            run_name="test_run",
         )
 
+        assert output.inputs == inputs
+        assert output.results.run_name == "test_run"
+        assert output.results.results == {
+            "metric_doc_map": {
+                "score": 0.7222222222222222,
+                "individual_scores": [1.0, 0.8333333333333333, 1.0, 0.5, 0.0, 1.0],
+            },
+            "metric_doc_recall_single": {
+                "score": 0.8333333333333334,
+                "individual_scores": [1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+            },
+            "metric_doc_recall_multi": {
+                "score": 0.75,
+                "individual_scores": [1.0, 1.0, 0.5, 1.0, 0.0, 1.0],
+            },
+            "metric_doc_mrr": {
+                "score": 0.75,
+                "individual_scores": [1.0, 1.0, 1.0, 0.5, 0.0, 1.0],
+            },
+        }
+        overriden_pipeline_dict = Pipeline.loads(output.evaluated_pipeline).to_dict()
+        assert (
+            overriden_pipeline_dict["components"]["generator"]["init_parameters"]["arg"]
+            == 100
+        )
 
-def test_rag_eval_harness_run_statistical_metrics():
-    harness = RAGEvaluationHarness.default_with_keyword_retriever(
-        build_rag_pipeline_with_keyword_retriever(
-            retriever_component=MockKeywordRetriever(),
-            generator_component=MockGenerator(arg=0),
-            generator_name="generator",
-        ),
-        metrics={
-            RAGEvaluationMetric.DOCUMENT_MAP,
-            RAGEvaluationMetric.DOCUMENT_MRR,
-            RAGEvaluationMetric.DOCUMENT_RECALL_SINGLE_HIT,
-            RAGEvaluationMetric.DOCUMENT_RECALL_MULTI_HIT,
-        },
-    )
+    def test_run_model_based_metrics(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
 
-    inputs = RAGEvaluationInput(
-        queries=["What is the capital of France?"] * 6,
-        ground_truth_documents=[
-            [Document(content="France")],
-            [Document(content="9th century"), Document(content="9th")],
-            [Document(content="classical music"), Document(content="classical")],
-            [Document(content="11th century"), Document(content="the 11th")],
-            [Document(content="Denmark, Iceland and Norway")],
-            [Document(content="10th century"), Document(content="10th")],
-        ],
-    )
+        metrics = {
+            RAGEvaluationMetric.ANSWER_FAITHFULNESS,
+            RAGEvaluationMetric.CONTEXT_RELEVANCE,
+            RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY,
+        }
+        harness = RAGEvaluationHarness.default_with_keyword_retriever(
+            build_rag_pipeline_with_keyword_retriever(
+                retriever_component=MockKeywordRetriever(),
+                generator_component=MockGenerator(arg=0),
+                generator_name="generator",
+            ),
+            metrics=metrics,
+        )
 
-    output = harness.run(
-        inputs,
-        overrides=RAGEvaluationOverrides(
-            rag_pipeline={
-                "generator": {"arg": 100},
-            }
-        ),
-        run_name="test_run",
-    )
+        mock_eval_pipeline = Pipeline()
+        for m in metrics:
+            mock_eval_pipeline.add_component(m.value, MockModelBasedEvaluator(metric=m))
 
-    assert output.inputs == inputs
-    assert output.results.run_name == "test_run"
-    assert output.results.results == {
-        "metric_doc_map": {
-            "score": 0.7222222222222222,
-            "individual_scores": [1.0, 0.8333333333333333, 1.0, 0.5, 0.0, 1.0],
-        },
-        "metric_doc_recall_single": {
-            "score": 0.8333333333333334,
-            "individual_scores": [1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
-        },
-        "metric_doc_recall_multi": {
-            "score": 0.75,
-            "individual_scores": [1.0, 1.0, 0.5, 1.0, 0.0, 1.0],
-        },
-        "metric_doc_mrr": {
-            "score": 0.75,
-            "individual_scores": [1.0, 1.0, 1.0, 0.5, 0.0, 1.0],
-        },
-    }
-    overriden_pipeline_dict = Pipeline.loads(output.evaluated_pipeline).to_dict()
-    assert (
-        overriden_pipeline_dict["components"]["generator"]["init_parameters"]["arg"]
-        == 100
-    )
+        harness.evaluation_pipeline = mock_eval_pipeline
+
+        inputs = RAGEvaluationInput(
+            queries=["What is the capital of France?"] * 6,
+            ground_truth_documents=[
+                [Document(content="France")],
+                [Document(content="9th century"), Document(content="9th")],
+                [Document(content="classical music"), Document(content="classical")],
+                [Document(content="11th century"), Document(content="the 11th")],
+                [Document(content="Denmark, Iceland and Norway")],
+                [Document(content="10th century"), Document(content="10th")],
+            ],
+            ground_truth_answers=[
+                "Paris is the capital of France.",
+                "9th century",
+                "classical music",
+                "11th century",
+                "Denmark, Iceland and Norway",
+                "10th century",
+            ],
+        )
+
+        output = harness.run(
+            inputs,
+            run_name="test_run",
+        )
+
+        assert output.inputs == inputs
+        assert output.results.run_name == "test_run"
+        assert output.results.results == {
+            "metric_answer_faithfulness": MockModelBasedEvaluator.default_output(
+                RAGEvaluationMetric.ANSWER_FAITHFULNESS
+            ),
+            "metric_context_relevance": MockModelBasedEvaluator.default_output(
+                RAGEvaluationMetric.CONTEXT_RELEVANCE
+            ),
+            "metric_sas": MockModelBasedEvaluator.default_output(
+                RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY
+            ),
+        }


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds support for using the `ContextRelevanceEvaluator` component with the RAG evaluation harness.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
