### PR TITLE
feat: LLM-based Evaluators have `raise_on_Failure=False` by default

### DIFF
--- a/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
+++ b/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
@@ -44,8 +44,8 @@ def default_rag_evaluation_pipeline(
         RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY: partial(
             SASEvaluator, model="sentence-transformers/all-MiniLM-L6-v2"
         ),
-        RAGEvaluationMetric.ANSWER_FAITHFULNESS: FaithfulnessEvaluator(raise_on_failure=False),
-        RAGEvaluationMetric.CONTEXT_RELEVANCE: ContextRelevanceEvaluator(raise_on_failure=False),
+        RAGEvaluationMetric.ANSWER_FAITHFULNESS: partial(FaithfulnessEvaluator, raise_on_failure=False),
+        RAGEvaluationMetric.CONTEXT_RELEVANCE: partial(ContextRelevanceEvaluator, raise_on_failure=False),
     }
 
     for metric in metrics:

--- a/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
+++ b/haystack_experimental/evaluation/harness/rag/evaluation_pipeline.py
@@ -44,8 +44,8 @@ def default_rag_evaluation_pipeline(
         RAGEvaluationMetric.SEMANTIC_ANSWER_SIMILARITY: partial(
             SASEvaluator, model="sentence-transformers/all-MiniLM-L6-v2"
         ),
-        RAGEvaluationMetric.ANSWER_FAITHFULNESS: FaithfulnessEvaluator,
-        RAGEvaluationMetric.CONTEXT_RELEVANCE: ContextRelevanceEvaluator,
+        RAGEvaluationMetric.ANSWER_FAITHFULNESS: FaithfulnessEvaluator(raise_on_failure=False),
+        RAGEvaluationMetric.CONTEXT_RELEVANCE: ContextRelevanceEvaluator(raise_on_failure=False),
     }
 
     for metric in metrics:


### PR DESCRIPTION
### Proposed Changes:

- LLM-based Evaluators have `raise_on_Failure=False` by default

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
