### PR TITLE
feat: Add ground truth documents and answers to RAG eval run results as inputs

### DIFF
--- a/haystack_experimental/evaluation/harness/rag/harness.py
+++ b/haystack_experimental/evaluation/harness/rag/harness.py
@@ -131,23 +131,31 @@ class RAGEvaluationHarness(
             pipeline_outputs["second"],
         )
 
+        result_inputs = {
+            "questions": inputs.queries,
+            "contexts": [
+                [doc.content for doc in docs]
+                for docs in self._lookup_component_output(
+                    RAGExpectedComponent.DOCUMENT_RETRIEVER,
+                    rag_outputs,
+                    "retrieved_documents",
+                )
+            ],
+            "responses": self._lookup_component_output(
+                RAGExpectedComponent.RESPONSE_GENERATOR, rag_outputs, "replies"
+            ),
+        }
+        if inputs.ground_truth_answers is not None:
+            result_inputs["ground_truth_answers"] = inputs.ground_truth_answers
+        if inputs.ground_truth_documents is not None:
+            result_inputs["ground_truth_documents"] = [
+                [doc.content for doc in docs] for docs in inputs.ground_truth_documents
+            ]
+
         assert run_name is not None
         run_results = EvaluationRunResult(
             run_name,
-            inputs={
-                "questions": inputs.queries,
-                "contexts": [
-                    [doc.content for doc in docs]
-                    for docs in self._lookup_component_output(
-                        RAGExpectedComponent.DOCUMENT_RETRIEVER,
-                        rag_outputs,
-                        "retrieved_documents",
-                    )
-                ],
-                "responses": self._lookup_component_output(
-                    RAGExpectedComponent.RESPONSE_GENERATOR, rag_outputs, "replies"
-                ),
-            },
+            inputs=result_inputs,
             results=eval_outputs,
         )
 

--- a/test/evaluation/harness/rag/test_harness.py
+++ b/test/evaluation/harness/rag/test_harness.py
@@ -664,6 +664,62 @@ class TestRAGEvaluationHarness:
 
         assert output.inputs == inputs
         assert output.results.run_name == "test_run"
+        assert output.results.inputs == {
+            "questions": ["What is the capital of France?"] * 6,
+            "contexts": [
+                ["France"],
+                [
+                    "9th century",
+                    "10th century",
+                    "9th",
+                ],
+                [
+                    "classical",
+                    "rock music",
+                    "dubstep",
+                ],
+                [
+                    "11th",
+                    "the 11th",
+                    "11th century",
+                ],
+                [
+                    "Denmark",
+                    "Norway",
+                    "Iceland",
+                ],
+                [
+                    "10th century",
+                    "the first half of the 10th century",
+                    "10th",
+                    "10th",
+                ],
+            ],
+            "responses": [
+                "placeholder",
+                "placeholder",
+                "placeholder",
+                "placeholder",
+                "placeholder",
+                "placeholder",
+            ],
+            "ground_truth_documents": [
+                ["France"],
+                ["9th century", "9th"],
+                ["classical music", "classical"],
+                ["11th century", "the 11th"],
+                ["Denmark, Iceland and Norway"],
+                ["10th century", "10th"],
+            ],
+            "ground_truth_answers": [
+                "Paris is the capital of France.",
+                "9th century",
+                "classical music",
+                "11th century",
+                "Denmark, Iceland and Norway",
+                "10th century",
+            ],
+        }
         assert output.results.results == {
             "metric_answer_faithfulness": MockModelBasedEvaluator.default_output(
                 RAGEvaluationMetric.ANSWER_FAITHFULNESS


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The ground truth inputs passed to the RAG eval harness were not being included in the final results. This PR rectifies that.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
