### PR TITLE
chore: Add OpenAIFuntionCaller to catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ The latest version of the package contains the following experiments:
 | Name                     | Type                    | Experiment end date |
 | ------------------------ | ----------------------- | ------------------- |
 | [`EvaluationHarness`][1] | Evaluation orchestrator | August 2024         |
+| [`OpenAIFunctionCaller`][2] | Function Calling Component | August 2024         |
 
 [1]: https://github.com/deepset-ai/haystack-experimental/tree/main/haystack_experimental/evaluation/harness
+[2]: https://github.com/deepset-ai/haystack-experimental/tree/main/haystack_experimental/components/tools/openai
 
 ## Usage
 


### PR DESCRIPTION
The OpenAIFunctionCaller component was added in https://github.com/deepset-ai/haystack-experimental/pull/14 but it's not listed in the catalogue in the readme yet. This PR adds the OpenAIFunctionCaller to the catalogue.