### PR TITLE
build: Fetch build version from Git tag

### DIFF
--- a/haystack_experimental/version.py
+++ b/haystack_experimental/version.py
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0
-
-__version__ = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.8.0"]
+requires = ["hatchling>=1.8.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -71,7 +71,8 @@ sync = "./.github/utils/pydoc-markdown.sh"
 delete-outdated = "python ./.github/utils/delete_outdated_docs.py {args}"
 
 [tool.hatch.version]
-path = "haystack_experimental/version.py"
+source = "vcs"
+tag-pattern = 'v(?P<version>.*)'
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -88,10 +89,7 @@ quiet-level = 3
 skip = "test/nodes/*,test/others/*,test/samples/*,e2e/*"
 
 [tool.pylint]
-ignore-paths = [
-  "haystack_experimental/__init__.py",
-  "haystack_experimental/version.py",
-]
+ignore-paths = ["haystack_experimental/__init__.py"]
 
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 120


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Streamlines the release process by directly reading the version from the Git tag, like we do with the core integrations.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
