### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
   rev: v2.2.5
   hooks:
   - id: codespell
+    args: [
+          "--ignore-words-list=ans,astroid,nd,ned,nin,ue,rouge,ist",
+          "--skip=test/nodes/*,test/others/*,test/samples/*,e2e/*",
+          "--quiet-level=3"
+        ]
     additional_dependencies:
       - tomli
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,3 @@ repos:
   hooks:
   - id: actionlint-docker
     args: ["-ignore", "SC2102"]
-
-- repo: local
-  hooks:
-  - id: pylint
-    name: pylint
-    entry: pylint
-    language: python
-    types: [python]
-    args: ["--rcfile=pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,9 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.0
   hooks:
-  - id: ruff
-  - id: ruff-format
+    - id: ruff
+      args: ["--config=pyproject.toml", "--select=ASYNC,C4,C90,E501,EXE,F,INT,PERF,PL,Q,SIM,SLOT,T10,W,YTT,I,A001,A002,A003,D102,D103,D209,D205,D213,D417,D419", "--ignore=F401,PERF203,PERF401,PLR1714,PLR5501,PLW0603,PLW1510,PLW2901,SIM108,SIM115,SIM118", "--line-length=120", "--target-version=py38"]
+    - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5
@@ -34,3 +35,12 @@ repos:
   hooks:
   - id: actionlint-docker
     args: ["-ignore", "SC2102"]
+
+- repo: local
+  hooks:
+  -   id: pylint
+      name: pylint
+      entry: pylint
+      language: python
+      types: [python]
+      args: ["--rcfile=pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,19 +19,13 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.0
   hooks:
-    - id: ruff
-      args: ["--config=pyproject.toml", "--select=ASYNC,C4,C90,E501,EXE,F,INT,PERF,PL,Q,SIM,SLOT,T10,W,YTT,I,A001,A002,A003,D102,D103,D209,D205,D213,D417,D419", "--ignore=F401,PERF203,PERF401,PLR1714,PLR5501,PLW0603,PLW1510,PLW2901,SIM108,SIM115,SIM118", "--line-length=120", "--target-version=py38"]
-    - id: ruff-format
+  - id: ruff
+  - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5
   hooks:
   - id: codespell
-    args: [
-          "--ignore-words-list=ans,astroid,nd,ned,nin,ue,rouge,ist",
-          "--skip=test/nodes/*,test/others/*,test/samples/*,e2e/*",
-          "--quiet-level=3"
-        ]
     additional_dependencies:
       - tomli
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+fail_fast: true
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-ast   # checks Python syntax
+    - id: check-json  # checks JSON syntax
+    - id: check-merge-conflict  # checks for no merge conflict strings
+    - id: check-shebang-scripts-are-executable  # checks all shell scripts have executable permissions
+    - id: check-toml  # checks TOML syntax
+    - id: check-yaml  # checks YAML syntax
+    - id: end-of-file-fixer  # checks there is a newline at the end of the file
+    - id: mixed-line-ending  # normalizes line endings
+    - id: no-commit-to-branch  # prevents committing to main
+    - id: trailing-whitespace  # trims trailing whitespace
+      args: [--markdown-linebreak-ext=md]
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.3.0
+  hooks:
+  - id: ruff
+  - id: ruff-format
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.5
+  hooks:
+  - id: codespell
+    additional_dependencies:
+      - tomli
+
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.6.25
+  hooks:
+  - id: actionlint-docker
+    args: ["-ignore", "SC2102"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,9 @@ repos:
 
 - repo: local
   hooks:
-  -   id: pylint
-      name: pylint
-      entry: pylint
-      language: python
-      types: [python]
-      args: ["--rcfile=pyproject.toml"]
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: python
+    types: [python]
+    args: ["--rcfile=pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,51 @@ max-line-length = 120
 disable = [
   "C0114", # missing-module-docstring
   "R0903", # too-few-public-methods
+  # To keep
+  "fixme",
+  "c-extension-no-member",
+
+  # To review:
+  "missing-docstring",
+  "unused-argument",
+  "no-member",
+  "line-too-long",
+  "protected-access",
+  "too-few-public-methods",
+  "raise-missing-from",
+  "invalid-name",
+  "duplicate-code",
+  "arguments-differ",
+  "consider-using-f-string",
+  "no-else-return",
+  "attribute-defined-outside-init",
+  "super-with-arguments",
+  "redefined-builtin",
+  "abstract-method",
+  "unspecified-encoding",
+  "unidiomatic-typecheck",
+  "no-name-in-module",
+  "consider-using-with",
+  "redefined-outer-name",
+  "arguments-renamed",
+  "unnecessary-pass",
+  "broad-except",
+  "unnecessary-comprehension",
+  "subprocess-run-check",
+  "singleton-comparison",
+  "consider-iterating-dictionary",
+  "undefined-loop-variable",
+  "consider-using-in",
+  "bare-except",
+  "unexpected-keyword-arg",
+  "simplifiable-if-expression",
+  "use-list-literal",
+  "broad-exception-raised",
+
+  # To review later
+  "cyclic-import",
+  "import-outside-toplevel",
+  "deprecated-method",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ Homepage = "https://github.com/deepset-ai/haystack-experimental"
 
 [tool.hatch.envs.default]
 dependencies = [
+  # Pre-commit hook
+  "pre-commit",
   # Type check
   "mypy",
   # Test


### PR DESCRIPTION
### Related Issues

- fixes [#7865](https://github.com/deepset-ai/haystack/issues/7865)

### Proposed Changes:

 Adds pre-commit hooks to the repo

### How did you test it?

Manual testing

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
