### PR TITLE
chore: Disable OpenAPITool firecrawl integration test

### DIFF
--- a/test/components/tools/openapi/test_openapi_client_live_openai.py
+++ b/test/components/tools/openapi/test_openapi_client_live_openai.py
@@ -61,6 +61,7 @@ class TestClientLiveOpenAPI:
     @pytest.mark.skipif("FIRECRAWL_API_KEY" not in os.environ, reason="FIRECRAWL_API_KEY not set")
     @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
+    @pytest.mark.skip("This test is flaky likely due to load on the popular Firecrawl API. Skip for now.")
     def test_firecrawl(self):
         openapi_spec_url = "https://raw.githubusercontent.com/mendableai/firecrawl/main/apps/api/openapi.json"
         config = ClientConfiguration(openapi_spec=create_openapi_spec(openapi_spec_url), credentials=os.getenv("FIRECRAWL_API_KEY"))


### PR DESCRIPTION
Firecrawl servers repeatedly hit read timeouts, most likely due to popularity of this service and insufficient capacity on their side. Disable for now continue to run manually, revisit in a month or so