### PR TITLE
chore: Adjust rdme sync docs command

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -64,4 +64,4 @@ jobs:
         if: github.event_name == 'push'
         uses: readmeio/rdme@v8
         with:
-          rdme: docs ./docs/pydoc/temp --key="${{ secrets.README_API_KEY }}" --version="${{ matrix.hs-docs-version }}"
+          rdme: docs ./docs/pydoc/temp --key=${{ secrets.README_API_KEY }} --version=${{ matrix.hs-docs-version }}


### PR DESCRIPTION
- Readme command [failed](https://github.com/deepset-ai/haystack-experimental/actions/runs/9791016152/job/27033871306)
- Most likely due to extra quotation around keys. See readme [docs](https://docs.readme.com/main/docs/rdme#securely-using-your-api-key) and our haystack project readme sync [workflow](https://github.com/deepset-ai/haystack/blob/main/.github/workflows/readme_sync.yml#L59)