### PR TITLE
chore: Update module names syntax in generated docs

### DIFF
--- a/docs/pydoc/config/harness.yml
+++ b/docs/pydoc/config/harness.yml
@@ -1,9 +1,9 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack_experimental/evaluation]
-    modules: ["harness/evaluation_harness",
-              "harness/rag/harness",
-              "harness/rag/parameters"]
+    search_path: [../../../]
+    modules: ["haystack_experimental.evaluation.harness.evaluation_harness",
+              "haystack_experimental.evaluation.harness.rag.harness",
+              "haystack_experimental.evaluation.harness.rag.parameters"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/docs/pydoc/config/openai_function_caller.yml
+++ b/docs/pydoc/config/openai_function_caller.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack_experimental/components/tools/openai]
-    modules: ["function_caller"]
+    search_path: [../../../]
+    modules: ["haystack_experimental.components.tools.openai.function_caller"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/docs/pydoc/config/openapitool.yml
+++ b/docs/pydoc/config/openapitool.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack_experimental/components/tools/openapi]
-    modules: ["openapi_tool"]
+    search_path: [../../../]
+    modules: ["haystack_experimental.components.tools.openapi.openapi_tool"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter


### PR DESCRIPTION
- Updates module syntax from this [format](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#module-harnessevaluation_harness) to this [format](https://docs.haystack.deepset.ai/v2.3-unstable/reference/integrations-chroma#module-haystack_integrationscomponentsretrieverschromaretriever)
- Verified with local build

This is the rendering of the local md build:

<img width="995" alt="Screenshot 2024-07-04 at 11 24 14" src="https://github.com/deepset-ai/haystack-experimental/assets/458335/a41200d2-877d-4828-8be3-caa89e19b6b4">
