### PR TITLE
feat/refactor: Allow pipelines without generators to be used with the RAG eval harness

### DIFF
--- a/haystack_experimental/evaluation/harness/rag/__init__.py
+++ b/haystack_experimental/evaluation/harness/rag/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .harness import RAGEvaluationHarness
+from .harness import DefaultRAGArchitecture, RAGEvaluationHarness
 from .parameters import (
     RAGEvaluationInput,
     RAGEvaluationMetric,
@@ -13,6 +13,7 @@ from .parameters import (
 )
 
 _all_ = [
+    "DefaultRAGArchitecture",
     "RAGEvaluationHarness",
     "RAGExpectedComponent",
     "RAGExpectedComponentMetadata",

--- a/haystack_experimental/evaluation/harness/rag/parameters.py
+++ b/haystack_experimental/evaluation/harness/rag/parameters.py
@@ -12,7 +12,7 @@ from haystack.evaluation.eval_run_result import EvaluationRunResult
 
 class RAGExpectedComponent(Enum):
     """
-    Represents the basic components in a RAG pipeline that needs to be present for evaluation.
+    Represents the basic components in a RAG pipeline that are, by default, required to be present for evaluation.
 
     Each of these can be separate components in the pipeline or a single component that performs
     multiple tasks.
@@ -27,6 +27,7 @@ class RAGExpectedComponent(Enum):
     DOCUMENT_RETRIEVER = "document_retriever"
 
     #: The component in a RAG pipeline that generates responses based on the query and the retrieved documents.
+    #: Can be optional if the harness is only evaluating retrieval.
     #: Expected outputs: `replies` - Name of out containing the LLM responses. Only the first response is used.
     RESPONSE_GENERATOR = "response_generator"
 
@@ -57,24 +58,31 @@ class RAGEvaluationMetric(Enum):
     """
 
     #: Document Mean Average Precision.
+    #: Required RAG components: Query Processor, Document Retriever.
     DOCUMENT_MAP = "metric_doc_map"
 
     #: Document Mean Reciprocal Rank.
+    #: Required RAG components: Query Processor, Document Retriever.
     DOCUMENT_MRR = "metric_doc_mrr"
 
     #: Document Recall with a single hit.
+    #: Required RAG components: Query Processor, Document Retriever.
     DOCUMENT_RECALL_SINGLE_HIT = "metric_doc_recall_single"
 
     #: Document Recall with multiple hits.
+    #: Required RAG components: Query Processor, Document Retriever.
     DOCUMENT_RECALL_MULTI_HIT = "metric_doc_recall_multi"
 
     #: Semantic Answer Similarity.
+    #: Required RAG components: Query Processor, Response Generator.
     SEMANTIC_ANSWER_SIMILARITY = "metric_sas"
 
     #: Faithfulness.
+    #: Required RAG components: Query Processor, Document Retriever, Response Generator.
     FAITHFULNESS = "metric_faithfulness"
 
     #: Context Relevance.
+    #: Required RAG components: Query Processor, Document Retriever.
     CONTEXT_RELEVANCE = "metric_context_relevance"
 
 


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds support for evaluating pipelines that do not contain a generator component, i.e., pure retrieval pipelines. With this addition, we have two more "default" architectures to support. To aid consistency, we now expose a `DefaultRAGArchitecture` enumeration that gets passed to the c'tor of `RAGEvaluationHarness`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
