### PR TITLE
Add google colab link to the example harness nb

### DIFF
--- a/examples/rag_eval_harness.ipynb
+++ b/examples/rag_eval_harness.ipynb
@@ -6,6 +6,8 @@
         "id": "03ixktWsySVK"
       },
       "source": [
+        "<a href=\"https://colab.research.google.com/github/deepset-ai/haystack-experimental/blob/main/examples/rag_eval_harness.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "\n",
         "# Evaluating RAG Pipelines with EvaluationHarness\n",
         "\n",
         "In this notebook, you'll learn how to use the [`EvaluationHarness`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#evaluationharness) from the [haystack-experimental](https://github.com/deepset-ai/haystack-experimental) repository to assess the performance of Retrieval-Augmented Generation (RAG) pipelines over the [SQUAD dataset](https://huggingface.co/datasets/rajpurkar/squad_v2).\n",


### PR DESCRIPTION
### Proposed Changes:

Add a Google Colab link to the notebook for smooth transition

### How did you test it?

This is what it looks like
<img width="802" alt="image" src="https://github.com/user-attachments/assets/d3123e64-7d16-409f-b544-98b2588dea94">

### Notes for the reviewer
N/A


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
