### PR TITLE
doc: Fix links to API docs and pip packages in RAG eval harness notebook

### DIFF
--- a/examples/rag_eval_harness.ipynb
+++ b/examples/rag_eval_harness.ipynb
@@ -69,8 +69,8 @@
       "source": [
         "%%bash\n",
         "\n",
-        "pip install -U git+https://github.com/deepset-ai/haystack-experimental.git@main\n",
-        "pip install git+https://github.com/deepset-ai/haystack@main\n",
+        "pip install -U haystack-ai\n",
+        "pip install -U haystack-experimental\n",
         "pip install datasets\n",
         "pip install sentence-transformers"
       ]
@@ -931,7 +931,7 @@
         "\n",
         "You will evaluate your RAG pipeline using the `EvaluationHarness`. The `EvaluationHarness` executes a pipeline with a given set of inputs and evaluates its outputs with an evaluation pipeline using Haystack's built-in [Evaluators](https://docs.haystack.deepset.ai/docs/evaluators). This means you don't need to create a separate evaluation pipeline.\n",
         "\n",
-        "The [`RAGEvaluationHarness`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#ragevaluationharness) class, derived from the Evaluation Harness, simplifies the evaluation process specifically for RAG pipelines. It comes with a predefined set of evaluation metrics, detailed in the [`RAGEvaluationMetric`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#ragevaluationmetric) enum, and basic RAG architecture examples, listed in the [`DefaultRAGArchitecture`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#defaultragarchitecture) enum.\n",
+        "The [`RAGEvaluationHarness`](https://docs.haystack.deepset.ai/reference/evaluation-harness#ragevaluationharness) class, derived from the Evaluation Harness, simplifies the evaluation process specifically for RAG pipelines. It comes with a predefined set of evaluation metrics, detailed in the [`RAGEvaluationMetric`](https://docs.haystack.deepset.ai/reference/evaluation-harness#ragevaluationmetric) enum, and basic RAG architecture examples, listed in the [`DefaultRAGArchitecture`](https://docs.haystack.deepset.ai/reference/evaluation-harness#defaultragarchitecture) enum.\n",
         "\n",
         "Now, create a harness to evaluate the embedding-based RAG pipeline. For evaluating the RAG pipeline mentioned above, use the `DefaultRAGArchitecture.GENERATION_WITH_EMBEDDING_RETRIEVAL` architecture. You will evaluate the pipeline using the [DocumentMAPEvaluator](https://docs.haystack.deepset.ai/docs/documentmapevaluator), [DocumentRecallEvaluator](https://docs.haystack.deepset.ai/docs/documentrecallevaluator), and [FaithfulnessEvaluator](https://docs.haystack.deepset.ai/docs/faithfulnessevaluator).\n"
       ]
@@ -1904,7 +1904,7 @@
       "source": [
         "## Evaluating and Comparing Different Pipelines\n",
         "\n",
-        "To evaluate alternative approaches, you can initiate another evaluation run using the same inputs but with different overrides, leveraging [`RAGEvaluationOverrides`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-harness#ragevaluationoverrides).\n",
+        "To evaluate alternative approaches, you can initiate another evaluation run using the same inputs but with different overrides, leveraging [`RAGEvaluationOverrides`](https://docs.haystack.deepset.ai/reference/evaluation-harness#ragevaluationoverrides).\n",
         "\n",
         "Now, update the model used with `OpenAIGenerator` in the RAG pipeline and execute the same EvaluationHarness instance:"
       ]
@@ -1941,7 +1941,7 @@
         "id": "Q1YPapD2wYyA"
       },
       "source": [
-        "Compare the results of the two evaluation runs with [`comparative_individual_scores_report()`](https://docs.haystack.deepset.ai/v2.3-unstable/reference/evaluation-api#baseevaluationrunresultcomparative_individual_scores_report). The results for the new pipeline will have the `emb_eval_run_gpt4_*` name."
+        "Compare the results of the two evaluation runs with [`comparative_individual_scores_report()`](https://docs.haystack.deepset.ai/reference/evaluation-api#baseevaluationrunresultcomparative_individual_scores_report). The results for the new pipeline will have the `emb_eval_run_gpt4_*` name."
       ]
     },
     {


### PR DESCRIPTION
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
