### PR TITLE
fix: Centralize OpenAPI schema reference resolution 

### DIFF
--- a/haystack_experimental/components/tools/openapi/_payload_extraction.py
+++ b/haystack_experimental/components/tools/openapi/_payload_extraction.py
@@ -4,7 +4,7 @@
 
 import dataclasses
 import json
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 
 def create_function_payload_extractor(
@@ -68,7 +68,8 @@ def _search(payload: Any, arguments_field_name: str) -> Dict[str, Any]:
     if dict_converter := _get_dict_converter(payload):
         payload = dict_converter()
     elif dataclasses.is_dataclass(payload):
-        payload = dataclasses.asdict(payload)
+        # Cast payload to Any to satisfy mypy 1.11.0
+        payload = dataclasses.asdict(cast(Any, payload))
     if isinstance(payload, dict):
         if all(field in payload for field in _required_fields(arguments_field_name)):
             # this is the payload we are looking for

--- a/haystack_experimental/components/tools/openapi/_schema_conversion.py
+++ b/haystack_experimental/components/tools/openapi/_schema_conversion.py
@@ -5,18 +5,11 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
-from haystack.lazy_imports import LazyImport
-
 from haystack_experimental.components.tools.openapi.types import (
     VALID_HTTP_METHODS,
     OpenAPISpecification,
     path_to_operation_id,
 )
-
-with LazyImport("Run 'pip install jsonref'") as jsonref_import:
-    # pylint: disable=import-error
-    import jsonref
-
 
 MIN_REQUIRED_OPENAPI_SPEC_VERSION = 3
 
@@ -31,10 +24,8 @@ def openai_converter(schema: OpenAPISpecification) -> List[Dict[str, Any]]:
     :param schema: The OpenAPI specification to convert.
     :returns: A list of dictionaries, each dictionary representing an OpenAI function definition.
     """
-    jsonref_import.check()
-    resolved_schema = jsonref.replace_refs(schema.spec_dict)
     fn_definitions = _openapi_to_functions(
-        resolved_schema, "parameters", _parse_endpoint_spec_openai
+        schema.spec_dict, "parameters", _parse_endpoint_spec_openai
     )
     return [{"type": "function", "function": fn} for fn in fn_definitions]
 
@@ -48,10 +39,9 @@ def anthropic_converter(schema: OpenAPISpecification) -> List[Dict[str, Any]]:
     :param schema: The OpenAPI specification to convert.
     :returns: A list of dictionaries, each dictionary representing Anthropic function definition.
     """
-    jsonref_import.check()
-    resolved_schema = jsonref.replace_refs(schema.spec_dict)
+
     return _openapi_to_functions(
-        resolved_schema, "input_schema", _parse_endpoint_spec_openai
+        schema.spec_dict, "input_schema", _parse_endpoint_spec_openai
     )
 
 
@@ -64,10 +54,8 @@ def cohere_converter(schema: OpenAPISpecification) -> List[Dict[str, Any]]:
     :param schema: The OpenAPI specification to convert.
     :returns: A list of dictionaries, each representing a Cohere style function definition.
     """
-    jsonref_import.check()
-    resolved_schema = jsonref.replace_refs(schema.spec_dict)
     return _openapi_to_functions(
-        resolved_schema, "not important for cohere", _parse_endpoint_spec_cohere
+        schema.spec_dict,"not important for cohere",_parse_endpoint_spec_cohere
     )
 
 

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -10,6 +10,12 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 import requests
 import yaml
+from haystack.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install jsonref'") as jsonref_import:
+    # pylint: disable=import-error
+    import jsonref
+
 
 VALID_HTTP_METHODS = [
     "get",
@@ -149,6 +155,7 @@ class OpenAPISpecification:
 
         :param spec_dict: The OpenAPI specification as a dictionary.
         """
+        jsonref_import.check()
         if not isinstance(spec_dict, Dict):
             raise ValueError(
                 f"Invalid OpenAPI specification, expected a dictionary: {spec_dict}"
@@ -159,7 +166,7 @@ class OpenAPISpecification:
                 "Invalid OpenAPI specification format. See https://swagger.io/specification/ for details.",
                 spec_dict,
             )
-        self.spec_dict = spec_dict
+        self.spec_dict = jsonref.replace_refs(spec_dict)
 
     @classmethod
     def from_str(cls, content: str) -> "OpenAPISpecification":

--- a/test/test_files/yaml/openapi_greeting_service.yml
+++ b/test/test_files/yaml/openapi_greeting_service.yml
@@ -9,11 +9,7 @@ paths:
     post:
       operationId: greet
       parameters:
-        - name: name
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/NameParameter'
       requestBody:
         required: true
         content:
@@ -238,6 +234,13 @@ components:
           tokenUrl: https://example.com/oauth/token
           scopes:
             read:greet: Read access to greeting service
+  parameters:
+    NameParameter:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
 
   schemas:
     GreetBody:


### PR DESCRIPTION
### Why:
Centralizes the OpenAPI schema reference resolution -> more simple and maintainable. Spec has references resolved at creation preventing subtle bugs (i.e parameters of an operationId not resolved properly).


### What:
- Introduced `jsonref` loading and replacement within the `OpenAPISpecification` class constructor, ensuring all references are resolved upon object instantiation.


### How can it be used:
- Not user facing

### How did you test it:
- Ensured existing unit tests for the converter functions passed with the refactored codebase to verify backward compatibility and correctness.
- Adjusted test [yaml service](https://github.com/deepset-ai/haystack-experimental/pull/40/files#diff-35c165d45fc56fa8436798b9114a89947df86be0def29d21e9639411a1527e18) to include parameter reference

### Notes for the reviewer:
- Pay special attention to how jsonref resolution was migrated to the `OpenAPISpecification` class constructor where instance variable `spec_dict` is by default reference resolved
- Review if the removal of `jsonref_import.check()` calls in converter functions could have any unintended side effects, although initial tests suggest the refactoring maintains the desired outcomes.
