### PR TITLE
fix: Sanitize function names and trim descriptions for LLM compatibility

### DIFF
--- a/haystack_experimental/components/tools/openapi/_schema_conversion.py
+++ b/haystack_experimental/components/tools/openapi/_schema_conversion.py
@@ -9,6 +9,7 @@ from haystack_experimental.components.tools.openapi.types import (
     VALID_HTTP_METHODS,
     OpenAPISpecification,
     path_to_operation_id,
+    sanitize,
 )
 
 MIN_REQUIRED_OPENAPI_SPEC_VERSION = 3
@@ -96,7 +97,7 @@ def _openapi_to_functions(
                 function_dict = parse_endpoint_fn(operation_spec, parameters_name)
                 if function_dict:
                     functions.append(function_dict)
-    return functions
+    return [sanitize(f) for f in functions]
 
 
 def _parse_endpoint_spec_openai(

--- a/haystack_experimental/components/tools/openapi/_schema_conversion.py
+++ b/haystack_experimental/components/tools/openapi/_schema_conversion.py
@@ -9,7 +9,7 @@ from haystack_experimental.components.tools.openapi.types import (
     VALID_HTTP_METHODS,
     OpenAPISpecification,
     path_to_operation_id,
-    sanitize,
+    sanitize_function_calling_definition,
 )
 
 MIN_REQUIRED_OPENAPI_SPEC_VERSION = 3
@@ -97,7 +97,7 @@ def _openapi_to_functions(
                 function_dict = parse_endpoint_fn(operation_spec, parameters_name)
                 if function_dict:
                     functions.append(function_dict)
-    return [sanitize(f) for f in functions]
+    return [sanitize_function_calling_definition(f) for f in functions]
 
 
 def _parse_endpoint_spec_openai(

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -41,7 +41,7 @@ def path_to_operation_id(path: str, http_method: str = "get") -> str:
     return sanitize_function_name(path + "_" + http_method.lower())
 
 
-def sanitize(data: Dict[str, Any]) -> Dict[str, Any]:
+def sanitize_function_calling_definition(data: Dict[str, Any]) -> Dict[str, Any]:
     """
     Sanitizes the given function calling definition by adjusting its properties to LLM requirements.
 
@@ -56,7 +56,7 @@ def sanitize(data: Dict[str, Any]) -> Dict[str, Any]:
             elif key == "description" and isinstance(value, str):
                 sanitized_data[key] = value[:1024]
             else:
-                sanitized_data[key] = sanitize(value)
+                sanitized_data[key] = sanitize_function_calling_definition(value)
         return sanitized_data
     else:
         return data

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -41,15 +41,15 @@ def path_to_operation_id(path: str, http_method: str = "get") -> str:
     return sanitize_function_name(path + "_" + http_method.lower())
 
 
-def sanitize(data: Dict[str, Any]) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+def sanitize(data: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Sanitizes the given function calling definition(s) by adjusting its properties to LLM requirements.
+    Sanitizes the given function calling definition by adjusting its properties to LLM requirements.
 
     :param data: The function calling definition(s) to sanitize.
     :return: A sanitized function calling definition.
     """
     if isinstance(data, dict):
-        sanitized_data = {}
+        sanitized_data: Dict[str, Any] = {}
         for key, value in data.items():
             if key == "name" and isinstance(value, str):
                 sanitized_data[key] = sanitize_function_name(value)
@@ -58,8 +58,6 @@ def sanitize(data: Dict[str, Any]) -> Union[List[Dict[str, Any]], Dict[str, Any]
             else:
                 sanitized_data[key] = sanitize(value)
         return sanitized_data
-    elif isinstance(data, list):
-        return [sanitize(item) for item in data]
     else:
         return data
 

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -37,9 +38,43 @@ def path_to_operation_id(path: str, http_method: str = "get") -> str:
     :param http_method: The HTTP method to use for the operationId.
     :returns: The operationId.
     """
-    if http_method.lower() not in VALID_HTTP_METHODS:
-        raise ValueError(f"Invalid HTTP method: {http_method}")
-    return path.replace("/", "_").lstrip("_").rstrip("_") + "_" + http_method.lower()
+    return sanitize_function_name(path + "_" + http_method.lower())
+
+
+def sanitize(data: Dict[str, Any]) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Sanitizes the given function calling definition(s) by adjusting its properties to LLM requirements.
+
+    :param data: The function calling definition(s) to sanitize.
+    :return: A sanitized function calling definition.
+    """
+    if isinstance(data, dict):
+        sanitized_data = {}
+        for key, value in data.items():
+            if key == "name" and isinstance(value, str):
+                sanitized_data[key] = sanitize_function_name(value)
+            elif key == "description" and isinstance(value, str):
+                sanitized_data[key] = value[:1024]
+            else:
+                sanitized_data[key] = sanitize(value)
+        return sanitized_data
+    elif isinstance(data, list):
+        return [sanitize(item) for item in data]
+    else:
+        return data
+
+
+def sanitize_function_name(name: str) -> str:
+    """
+    Sanitizes the function name to match the LLM function naming pattern ^[a-zA-Z0-9_-]+$.
+
+    :param name: The original function name.
+    :return: A sanitized function name that matches the allowed pattern.
+    """
+    # Replace characters not allowed in the pattern with underscores
+    sanitized = re.sub(r"[^a-zA-Z0-9_]+", "_", name)
+    # Remove leading and trailing underscores
+    return sanitized.strip("_")
 
 
 class LLMProvider(Enum):
@@ -238,12 +273,8 @@ class OpenAPISpecification:
             }
 
             for method, operation_dict in operations.items():
-                if (
-                    operation_dict.get(
-                        "operationId", path_to_operation_id(path, method)
-                    )
-                    == op_id
-                ):
+                operation_id = operation_dict.get("operationId", path_to_operation_id(path, method))
+                if sanitize_function_name(operation_id) == op_id:
                     return Operation(path, method, operation_dict, self.spec_dict)
         raise ValueError(f"No operation found with operationId {op_id}")
 

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -67,7 +67,7 @@ def sanitize_function_name(name: str) -> str:
     Sanitizes the function name to match the LLM function naming pattern ^[a-zA-Z0-9_-]+$.
 
     :param name: The original function name.
-    :return: A sanitized function name that matches the allowed pattern.
+    :returns: A sanitized function name that matches the allowed pattern.
     """
     # Replace characters not allowed in the pattern with underscores
     sanitized = re.sub(r"[^a-zA-Z0-9_]+", "_", name)

--- a/haystack_experimental/components/tools/openapi/types.py
+++ b/haystack_experimental/components/tools/openapi/types.py
@@ -46,7 +46,7 @@ def sanitize(data: Dict[str, Any]) -> Dict[str, Any]:
     Sanitizes the given function calling definition by adjusting its properties to LLM requirements.
 
     :param data: The function calling definition(s) to sanitize.
-    :return: A sanitized function calling definition.
+    :returns: A sanitized function calling definition.
     """
     if isinstance(data, dict):
         sanitized_data: Dict[str, Any] = {}

--- a/test/components/tools/openapi/test_openapi_client_edge_cases.py
+++ b/test/components/tools/openapi/test_openapi_client_edge_cases.py
@@ -36,7 +36,7 @@ class TestEdgeCases:
         tools = config.get_tools_definitions(),
         tool_def = tools[0][0]
         assert tool_def["type"] == "function"
-        assert tool_def["function"]["name"] == "missing-operation-id_get"
+        assert tool_def["function"]["name"] == "missing_operation_id_get"
 
     def test_servers_order(self, test_files_path):
         """
@@ -46,9 +46,9 @@ class TestEdgeCases:
         config = ClientConfiguration(openapi_spec=create_openapi_spec(test_files_path / "yaml" / "openapi_edge_cases.yml"),
                                      request_sender=FastAPITestClient(None))
 
-        op = config.openapi_spec.find_operation_by_id("servers-order-path")
+        op = config.openapi_spec.find_operation_by_id("servers_order_path")
         assert op.get_server() == "https://inpath.example.com"
-        op = config.openapi_spec.find_operation_by_id("servers-order-operation")
+        op = config.openapi_spec.find_operation_by_id("servers_order_operation")
         assert op.get_server() == "https://inoperation.example.com"
-        op = config.openapi_spec.find_operation_by_id("missing-operation-id_get")
+        op = config.openapi_spec.find_operation_by_id("missing_operation_id_get")
         assert op.get_server() == "http://localhost"

--- a/test/components/tools/openapi/test_util.py
+++ b/test/components/tools/openapi/test_util.py
@@ -1,0 +1,36 @@
+from haystack_experimental.components.tools.openapi.types import sanitize_function_name, sanitize
+
+
+def test_sanitize_function_name():
+    assert sanitize_function_name("test-function") == "test_function"
+    assert sanitize_function_name("missing-operation-id_get") == "missing_operation_id_get"
+    assert sanitize_function_name("/test/function/with/slashes-and-dashes") == "test_function_with_slashes_and_dashes"
+    assert sanitize_function_name("test\\function\\with\\backslashes") == "test_function_with_backslashes"
+    assert sanitize_function_name("-test-function-with-dashes-") == "test_function_with_dashes"
+
+
+def test_sanitize():
+    function = {
+        "name": "_test-function/with/slashes-and-dashes_",
+        "description": "Test function description at least 50 characters long " * 100,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA" * 100,
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["celsius", "fahrenheit"],
+                    "description": "The temperature unit to use. Infer this from the users location.",
+                },
+            },
+            "required": ["location", "format"],
+        }
+    }
+    sanitized_function = sanitize(function)
+    assert sanitized_function["name"] == "test_function_with_slashes_and_dashes"
+    assert len(sanitized_function["description"]) <= 1024
+    assert len(sanitized_function["parameters"]["properties"]["location"]["description"]) <= 1024
+    assert len(sanitized_function["parameters"]["properties"]["format"]["description"]) <= 1024

--- a/test/components/tools/openapi/test_util.py
+++ b/test/components/tools/openapi/test_util.py
@@ -1,4 +1,4 @@
-from haystack_experimental.components.tools.openapi.types import sanitize_function_name, sanitize
+from haystack_experimental.components.tools.openapi.types import sanitize_function_name, sanitize_function_calling_definition
 
 
 def test_sanitize_function_name():
@@ -29,7 +29,7 @@ def test_sanitize():
             "required": ["location", "format"],
         }
     }
-    sanitized_function = sanitize(function)
+    sanitized_function = sanitize_function_calling_definition(function)
     assert sanitized_function["name"] == "test_function_with_slashes_and_dashes"
     assert len(sanitized_function["description"]) <= 1024
     assert len(sanitized_function["parameters"]["properties"]["location"]["description"]) <= 1024


### PR DESCRIPTION
#### Why:
Fixes subtle naming bugs to meet LLM naming requirements for function naming patterns and description length limitations. 
Not all operation names from OpenAPI spec and long descriptions are accepted by LLMs.

#### What:
- Implemented function name sanitization to match pattern `^[a-zA-Z0-9_-]+$`
- Trimmed descriptions to max 1024 characters
- Updated schema conversion and operation finding logic
- Added and expanded tests

#### How:
```python
sanitized_name = sanitize_function_name("function-name/with/special_chars")
# Result: "function_name_with_special_chars"

sanitized_desc = sanitize({"description": "Long text..."})
# Result: {"description": "Trimmed to 1024 characters..."}
```

#### How did you test it:
- Unit tests for sanitization functions
- Updated integration tests for edge cases
- Verified compatibility with existing schemas

#### Notes for the reviewer:
- Regex pattern alignment with LLM conventions
- Consistency of sanitized names across the codebase