### PR TITLE
fix: fix `OpenAPITool` notebook

### DIFF
--- a/examples/openapitool.ipynb
+++ b/examples/openapitool.ipynb
@@ -87,7 +87,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -95,18 +95,7 @@
         "id": "MDy213SLXZQy",
         "outputId": "4e9e1607-4212-4ce7-e409-ded548f83ab0"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'service_response': [ChatMessage(content='{\"latitude\": 37.763283, \"longitude\": -122.41286, \"generationtime_ms\": 0.07903575897216797, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 18.0, \"current_weather_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature\": \"\\\\u00b0C\", \"windspeed\": \"km/h\", \"winddirection\": \"\\\\u00b0\", \"is_day\": \"\", \"weathercode\": \"wmo code\"}, \"current_weather\": {\"time\": \"2024-07-22T16:45\", \"interval\": 900, \"temperature\": 18.1, \"windspeed\": 3.4, \"winddirection\": 212, \"is_day\": 1, \"weathercode\": 1}}', role=<ChatRole.USER: 'user'>, name=None, meta={})]}"
-            ]
-          },
-          "execution_count": 2,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from haystack.dataclasses import ChatMessage\n",
         "from haystack_experimental.components.tools.openapi import OpenAPITool, LLMProvider\n",
@@ -128,12 +117,12 @@
         "\n",
         "Next, let's create a simple Pipeline where the service response is translated into a human-understandable format using the Language Model.\n",
         "\n",
-        "We use an [`OutputAdapter`](https://docs.haystack.deepset.ai/docs/outputadapter) to create a list of Chat Messages for the LM."
+        "We use a [`ChatPromptBuilder`](https://docs.haystack.deepset.ai/docs/chatpromptbuilder) to create a list of Chat Messages for the LM."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -145,17 +134,17 @@
         {
           "data": {
             "text/plain": [
-              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7b8db7235720>\n",
+              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7f8899ea5bd0>\n",
               "🚅 Components\n",
               "  - meteo: OpenAPITool\n",
-              "  - prompt_adapter: OutputAdapter\n",
+              "  - builder: ChatPromptBuilder\n",
               "  - llm: OpenAIChatGenerator\n",
               "🛤️ Connections\n",
-              "  - meteo.service_response -> prompt_adapter.service_response (List[ChatMessage])\n",
-              "  - prompt_adapter.output -> llm.messages (List[ChatMessage])"
+              "  - meteo.service_response -> builder.service_response (List[ChatMessage])\n",
+              "  - builder.prompt -> llm.messages (List[ChatMessage])"
             ]
           },
-          "execution_count": 3,
+          "execution_count": 7,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -163,16 +152,19 @@
       "source": [
         "from typing import List\n",
         "from haystack import Pipeline\n",
-        "from haystack.components.converters import OutputAdapter\n",
+        "from haystack.components.builders import ChatPromptBuilder\n",
         "from haystack.components.generators.chat import OpenAIChatGenerator\n",
+        "\n",
+        "messages = [ChatMessage.from_user(\"{{user_message}}\"), ChatMessage.from_user(\"{{service_response}}\")]\n",
+        "builder = ChatPromptBuilder(template=messages)\n",
         "\n",
         "pipe = Pipeline()\n",
         "pipe.add_component(\"meteo\", tool)\n",
-        "pipe.add_component(\"prompt_adapter\", OutputAdapter(\"{{user_message + service_response}}\", List[ChatMessage]))\n",
+        "pipe.add_component(\"builder\", builder)\n",
         "pipe.add_component(\"llm\", OpenAIChatGenerator(generation_kwargs={\"max_tokens\": 1024}))\n",
         "\n",
-        "pipe.connect(\"meteo\", \"prompt_adapter.service_response\")\n",
-        "pipe.connect(\"prompt_adapter\", \"llm.messages\")"
+        "pipe.connect(\"meteo\", \"builder.service_response\")\n",
+        "pipe.connect(\"builder\", \"llm.messages\")"
       ]
     },
     {
@@ -184,7 +176,7 @@
       "outputs": [],
       "source": [
         "result = pipe.run(data={\"meteo\": {\"messages\": [ChatMessage.from_user(\"weather in San Francisco, US\")]},\n",
-        "                        \"prompt_adapter\": {\"user_message\": [ChatMessage.from_user(\"Explain the weather in San Francisco in a human understandable way\")]}})"
+        "                        \"builder\": {\"user_message\": [ChatMessage.from_user(\"Explain the weather in San Francisco in a human understandable way\")]}})"
       ]
     },
     {
@@ -225,7 +217,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -237,31 +229,35 @@
         {
           "data": {
             "text/plain": [
-              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7b8d53d03c40>\n",
+              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7f8899ea6ef0>\n",
               "🚅 Components\n",
               "  - firecrawl: OpenAPITool\n",
-              "  - prompt_adapter: OutputAdapter\n",
+              "  - builder: ChatPromptBuilder\n",
               "  - llm: OpenAIChatGenerator\n",
               "🛤️ Connections\n",
-              "  - firecrawl.service_response -> prompt_adapter.service_response (List[ChatMessage])\n",
-              "  - prompt_adapter.output -> llm.messages (List[ChatMessage])"
+              "  - firecrawl.service_response -> builder.service_response (List[ChatMessage])\n",
+              "  - builder.prompt -> llm.messages (List[ChatMessage])"
             ]
           },
-          "execution_count": 6,
+          "execution_count": 9,
           "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
+        "messages = [ChatMessage.from_user(\"{{user_message}}\"), ChatMessage.from_user(\"{{service_response}}\")]\n",
+        "builder = ChatPromptBuilder(template=messages)\n",
+        "\n",
+        "\n",
         "pipe = Pipeline()\n",
         "pipe.add_component(\"firecrawl\", OpenAPITool(generator_api=LLMProvider.OPENAI,\n",
         "                                            spec=\"https://raw.githubusercontent.com/mendableai/firecrawl/main/apps/api/openapi.json\",\n",
         "                                            credentials=Secret.from_env_var(\"FIRECRAWL_API_KEY\")))\n",
-        "pipe.add_component(\"prompt_adapter\", OutputAdapter(\"{{user_message + service_response}}\", List[ChatMessage]))\n",
+        "pipe.add_component(\"builder\", builder)\n",
         "pipe.add_component(\"llm\", OpenAIChatGenerator(generation_kwargs={\"max_tokens\": 1024}))\n",
         "\n",
-        "pipe.connect(\"firecrawl\", \"prompt_adapter.service_response\")\n",
-        "pipe.connect(\"prompt_adapter\", \"llm.messages\")"
+        "pipe.connect(\"firecrawl\", \"builder.service_response\")\n",
+        "pipe.connect(\"builder\", \"llm.messages\")"
       ]
     },
     {
@@ -275,7 +271,7 @@
         "user_prompt = \"Given the article below, list the most important facts in a bulleted list. Do not include repetitions. Max 5 points.\"\n",
         "\n",
         "result = pipe.run(data={\"firecrawl\": {\"messages\": [ChatMessage.from_user(\"Scrape https://lite.cnn.com/2024/07/18/style/rome-ancient-papal-palace/index.html\")]},\n",
-        "                        \"prompt_adapter\": {\"user_message\": [ChatMessage.from_user(user_prompt)]}})"
+        "                        \"builder\": {\"user_message\": [ChatMessage.from_user(user_prompt)]}})"
       ]
     },
     {
@@ -320,7 +316,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "metadata": {
         "id": "73ypFwhtKbH9"
       },
@@ -368,22 +364,19 @@
         "  except:\n",
         "    return \"error\"\n",
         "\n",
-        "def create_chat_message(query):\n",
-        "  return [ChatMessage.from_user(query)]\n",
-        "\n",
         "\n",
         "routes = [\n",
         "    {\n",
         "        \"condition\": \"{{replies[0] | get_tool_name == 'search_web'}}\",\n",
-        "        \"output\": \"{{query | create_chat_message}}\",\n",
+        "        \"output\": \"{{query}}\",\n",
         "        \"output_name\": \"search_web\",\n",
-        "        \"output_type\": List[ChatMessage],\n",
+        "        \"output_type\": str,\n",
         "    },\n",
         "    {\n",
         "        \"condition\": \"{{replies[0] | get_tool_name == 'scrape_page'}}\",\n",
-        "        \"output\": \"{{query | create_chat_message}}\",\n",
+        "        \"output\": \"{{query}}\",\n",
         "        \"output_name\": \"scrape_page\",\n",
-        "        \"output_type\": List[ChatMessage],\n",
+        "        \"output_type\": str,\n",
         "    },\n",
         "    {\n",
         "        \"condition\": \"{{replies[0] | get_tool_name == 'none'}}\",\n",
@@ -402,7 +395,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -414,29 +407,39 @@
         {
           "data": {
             "text/plain": [
-              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7b8d53caa410>\n",
+              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7f8899ea57e0>\n",
               "🚅 Components\n",
               "  - prompt_builder: PromptBuilder\n",
               "  - llm: OpenAIGenerator\n",
               "  - router: ConditionalRouter\n",
+              "  - search_web_chat_builder: ChatPromptBuilder\n",
+              "  - scrape_page_chat_builder: ChatPromptBuilder\n",
               "  - search_web_tool: OpenAPITool\n",
               "  - scrape_page_tool: OpenAPITool\n",
               "🛤️ Connections\n",
               "  - prompt_builder.prompt -> llm.prompt (str)\n",
               "  - llm.replies -> router.replies (List[str])\n",
-              "  - router.search_web -> search_web_tool.messages (List[ChatMessage])\n",
-              "  - router.scrape_page -> scrape_page_tool.messages (List[ChatMessage])"
+              "  - router.search_web -> search_web_chat_builder.query (str)\n",
+              "  - router.scrape_page -> scrape_page_chat_builder.query (str)\n",
+              "  - search_web_chat_builder.prompt -> search_web_tool.messages (List[ChatMessage])\n",
+              "  - scrape_page_chat_builder.prompt -> scrape_page_tool.messages (List[ChatMessage])"
             ]
           },
-          "execution_count": 10,
+          "execution_count": 13,
           "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
-        "from haystack.components.builders.prompt_builder import PromptBuilder\n",
+        "from haystack.components.builders import PromptBuilder, ChatPromptBuilder\n",
         "from haystack.components.routers import ConditionalRouter\n",
         "from haystack.components.generators import OpenAIGenerator\n",
+        "\n",
+        "\n",
+        "messages = [ChatMessage.from_user(\"{{query}}\")]\n",
+        "\n",
+        "search_web_chat_builder = ChatPromptBuilder(template=messages)\n",
+        "scrape_page_chat_builder = ChatPromptBuilder(template=messages)\n",
         "\n",
         "search_web_tool = OpenAPITool(generator_api=LLMProvider.OPENAI,\n",
         "                   spec=\"https://bit.ly/serper_dev_spec_yaml\",\n",
@@ -449,15 +452,18 @@
         "pipe = Pipeline()\n",
         "pipe.add_component(\"prompt_builder\", PromptBuilder(template=decision_prompt_template))\n",
         "pipe.add_component(\"llm\", OpenAIGenerator())\n",
-        "pipe.add_component(\"router\", ConditionalRouter(routes, custom_filters={\"get_tool_name\": get_tool_name,\n",
-        "                                                                       \"create_chat_message\": create_chat_message}))\n",
+        "pipe.add_component(\"router\", ConditionalRouter(routes, custom_filters={\"get_tool_name\": get_tool_name}))\n",
+        "pipe.add_component(\"search_web_chat_builder\", search_web_chat_builder)\n",
+        "pipe.add_component(\"scrape_page_chat_builder\", scrape_page_chat_builder)\n",
         "pipe.add_component(\"search_web_tool\", search_web_tool)\n",
         "pipe.add_component(\"scrape_page_tool\", scrape_page_tool)\n",
         "\n",
         "pipe.connect(\"prompt_builder\", \"llm\")\n",
         "pipe.connect(\"llm.replies\", \"router.replies\")\n",
-        "pipe.connect(\"router.search_web\", \"search_web_tool\")\n",
-        "pipe.connect(\"router.scrape_page\", \"scrape_page_tool\")"
+        "pipe.connect(\"router.search_web\", \"search_web_chat_builder\")\n",
+        "pipe.connect(\"router.scrape_page\", \"scrape_page_chat_builder\")\n",
+        "pipe.connect(\"search_web_chat_builder\", \"search_web_tool\")\n",
+        "pipe.connect(\"scrape_page_chat_builder\", \"scrape_page_tool\")"
       ]
     },
     {
@@ -538,8 +544,16 @@
       "name": "python3"
     },
     "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
       "name": "python",
-      "version": "3.10.13"
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
     }
   },
   "nbformat": 4,

--- a/examples/openapitool.ipynb
+++ b/examples/openapitool.ipynb
@@ -87,7 +87,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -95,7 +95,18 @@
         "id": "MDy213SLXZQy",
         "outputId": "4e9e1607-4212-4ce7-e409-ded548f83ab0"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'service_response': [ChatMessage(content='{\"latitude\": 37.763283, \"longitude\": -122.41286, \"generationtime_ms\": 0.07700920104980469, \"utc_offset_seconds\": -25200, \"timezone\": \"America/Los_Angeles\", \"timezone_abbreviation\": \"PDT\", \"elevation\": 18.0, \"current_weather_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature\": \"\\\\u00b0C\", \"windspeed\": \"km/h\", \"winddirection\": \"\\\\u00b0\", \"is_day\": \"\", \"weathercode\": \"wmo code\"}, \"current_weather\": {\"time\": \"2024-07-29T06:45\", \"interval\": 900, \"temperature\": 13.2, \"windspeed\": 12.7, \"winddirection\": 263, \"is_day\": 1, \"weathercode\": 45}}', role=<ChatRole.USER: 'user'>, name=None, meta={})]}"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "from haystack.dataclasses import ChatMessage\n",
         "from haystack_experimental.components.tools.openapi import OpenAPITool, LLMProvider\n",
@@ -122,7 +133,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -134,7 +145,7 @@
         {
           "data": {
             "text/plain": [
-              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7f8899ea5bd0>\n",
+              "<haystack.core.pipeline.pipeline.Pipeline object at 0x7f8899207e50>\n",
               "🚅 Components\n",
               "  - meteo: OpenAPITool\n",
               "  - builder: ChatPromptBuilder\n",
@@ -144,7 +155,7 @@
               "  - builder.prompt -> llm.messages (List[ChatMessage])"
             ]
           },
-          "execution_count": 7,
+          "execution_count": 15,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -169,7 +180,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "metadata": {
         "id": "6yF2RyfQhAaV"
       },
@@ -181,7 +192,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -194,7 +205,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Currently in San Francisco, the weather can be described as mild with a temperature of 18.1°C (64.6°F). The wind is blowing at a speed of 3.4 km/h coming from the south-southwest direction. It is daytime in San Francisco at the moment.\n"
+            "The current weather in San Francisco is 13.2°C with a windspeed of 12.7 km/h coming from the west-southwest. It is currently daytime and the weather code indicates that it is partly cloudy.\n"
           ]
         }
       ],


### PR DESCRIPTION
### Related Issues
For security reasons, https://github.com/deepset-ai/haystack/pull/8095 removed the ability to specify non-native python output types (such as `List[ChatMessage]`).
Unfortunately, this broke the `OpenAPITool` notebook.

### Proposed Changes:
I found some alternative ways to do the same.

Something can certainly be improved, but I don't think it is worth the effort.

### How did you test it?
Manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
