### PR TITLE
feat: update `ChatMessage` to support tools

### DIFF
--- a/docs/pydoc/config/data_classes_api.yml
+++ b/docs/pydoc/config/data_classes_api.yml
@@ -1,0 +1,27 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../]
+    modules: ["haystack_experimental.dataclasses.chat_message"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
+  excerpt: Core classes that carry data through the system.
+  category_slug: experiments-api
+  title: Data Classes
+  slug: data-classes-api
+  order: 30
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: data_classess_api.md

--- a/haystack_experimental/dataclasses/__init__.py
+++ b/haystack_experimental/dataclasses/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack_experimental.dataclasses.chat_message import ChatMessage, ChatRole, ToolCall
+from haystack_experimental.dataclasses.chat_message import ChatMessage, ChatRole, TextContent, ToolCall, ToolCallResult
 
-__all__ = ["ChatMessage", "ChatRole", "ToolCall"]
+__all__ = ["ChatMessage", "ChatRole", "ToolCall", "ToolCallResult", "TextContent"]

--- a/haystack_experimental/dataclasses/__init__.py
+++ b/haystack_experimental/dataclasses/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_experimental.dataclasses.chat_message import ChatMessage, ChatRole, ToolCall
+
+__all__ = ["ChatMessage", "ChatRole", "ToolCall"]

--- a/haystack_experimental/dataclasses/__init__.py
+++ b/haystack_experimental/dataclasses/__init__.py
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack_experimental.dataclasses.chat_message import ChatMessage, ChatRole, TextContent, ToolCall, ToolCallResult
+from haystack_experimental.dataclasses.chat_message import (
+    ChatMessage,
+    ChatMessageContentT,
+    ChatRole,
+    TextContent,
+    ToolCall,
+    ToolCallResult,
+)
 
-__all__ = ["ChatMessage", "ChatRole", "ToolCall", "ToolCallResult", "TextContent"]
+__all__ = ["ChatMessage", "ChatRole", "ToolCall", "ToolCallResult", "TextContent", "ChatMessageContentT"]

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -19,16 +19,19 @@ class ChatRole(str, Enum):
 @dataclass
 class ToolCall:
     """
-    Represents a Tool call prepared by the model, usually wrapped in an assistant message.
+    Represents a tool call prepared by the model.
 
-    :param id: The ID of the Tool call.
-    :param tool_name: The name of the Tool to call.
-    :param arguments: The arguments to call the Tool with.
+    It is usually stored in the `tool_calls` attribute of a message from the assistant.
+
+    :param tool_name: The name of the tool to be invoked.
+    :param arguments: The arguments to pass to the tool.
+    :param id: A unique identifier for the tool call. Some providers, such as OpenAI, generate this ID to associate
+        subsequent tool messages to the corresponding tool calls.
     """
 
-    id: str  # noqa: A003
     tool_name: str
     arguments: Dict[str, Any]
+    id: Optional[str]  # noqa: A003
 
 
 @dataclass
@@ -38,8 +41,8 @@ class ChatMessage:
 
     :param content: The text content of the message.
     :param role: The role of the entity sending the message.
-    :tool_call_id: The ID of the tool call that this message is responding to. Applies only to messages from tools.
-    :tool_calls: List of prepared tool calls. Applies only to messages from the assistant.
+    :tool_call_id: The ID of the tool call that a message from a tool is responding to (for messages from tools only).
+    :tool_calls: List of tool calls prepared by the model (for messages from the assistant only).
     :param meta: Additional metadata associated with the message.
     """
 
@@ -66,7 +69,7 @@ class ChatMessage:
         Create a message from the assistant.
 
         :param content: The text content of the message.
-        :param tool_calls: List of prepared tool calls.
+        :param tool_calls: List of tool calls prepared by the model.
         :param meta: Additional metadata associated with the message.
         :returns: A new ChatMessage instance.
         """
@@ -95,12 +98,12 @@ class ChatMessage:
         return cls(content=content, role=ChatRole.SYSTEM, tool_call_id=None, tool_calls=[], meta={})
 
     @classmethod
-    def from_tool(cls, content: str, tool_call_id: str) -> "ChatMessage":
+    def from_tool(cls, content: str, tool_call_id: Optional[str] = None) -> "ChatMessage":
         """
         Create a message from a tool.
 
         :param content: Content of the tool message.
-        :param tool_call_id: Tool call that this message is responding to.
+        :param tool_call_id: The ID of the tool call this message is responding to.
         :returns: A new ChatMessage instance.
         """
         return cls(content=content, role=ChatRole.TOOL, tool_call_id=tool_call_id, tool_calls=[], meta={})

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ChatRole(str, Enum):
+    """Enumeration representing the roles within a chat."""
+
+    ASSISTANT = "assistant"
+    USER = "user"
+    SYSTEM = "system"
+    TOOL = "tool"
+
+
+@dataclass
+class ToolCall:
+    """
+    Represents a Tool call prepared by the model, usually wrapped in an assistant message.
+
+    :param id: The ID of the Tool call.
+    :param tool_name: The name of the Tool to call.
+    :param arguments: The arguments to call the Tool with.
+    """
+
+    id: str
+    tool_name: str
+    arguments: Dict[str, Any]
+
+
+@dataclass
+class ChatMessage:
+    """
+    Represents a message in a LLM chat conversation.
+
+    :param content: The text content of the message.
+    :param role: The role of the entity sending the message.
+    :tool_call_id: The ID of the tool call that this message is responding to. Applies only to messages from tools.
+    :tool_calls: List of prepared tool calls. Applies only to messages from the assistant.
+    :param meta: Additional metadata associated with the message.
+    """
+
+    content: str
+    role: ChatRole
+    tool_call_id: Optional[str] = None
+    tool_calls: List[ToolCall] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict, hash=False)
+
+    def is_from(self, role: ChatRole) -> bool:
+        """
+        Check if the message is from a specific role.
+
+        :param role: The role to check against.
+        :returns: True if the message is from the specified role, False otherwise.
+        """
+        return self.role == role
+
+    @classmethod
+    def from_assistant(
+        cls, content: str, tool_calls: Optional[List[ToolCall]] = None, meta: Optional[Dict[str, Any]] = None
+    ) -> "ChatMessage":
+        """
+        Create a message from the assistant.
+
+        :param content: The text content of the message.
+        :param tool_calls: List of prepared tool calls.
+        :param meta: Additional metadata associated with the message.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(
+            content=content, role=ChatRole.ASSISTANT, tool_call_id=None, tool_calls=tool_calls or [], meta=meta or {}
+        )
+
+    @classmethod
+    def from_user(cls, content: str) -> "ChatMessage":
+        """
+        Create a message from the user.
+
+        :param content: The text content of the message.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(content=content, role=ChatRole.USER, tool_call_id=None, tool_calls=[], meta={})
+
+    @classmethod
+    def from_system(cls, content: str) -> "ChatMessage":
+        """
+        Create a message from the system.
+
+        :param content: The text content of the message.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(content=content, role=ChatRole.SYSTEM, tool_call_id=None, tool_calls=[], meta={})
+
+    @classmethod
+    def from_tool(cls, content: str, tool_call_id: str) -> "ChatMessage":
+        """
+        Create a message from a tool.
+
+        :param content: Content of the tool message.
+        :param tool_call_id: Tool call that this message is responding to.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(content=content, role=ChatRole.TOOL, tool_call_id=tool_call_id, tool_calls=[], meta={})
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Converts ChatMessage into a dictionary.
+
+        :returns:
+            Serialized version of the object.
+        """
+        data = asdict(self)
+        data["role"] = self.role.value
+
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChatMessage":
+        """
+        Creates a new ChatMessage object from a dictionary.
+
+        :param data:
+            The dictionary to build the ChatMessage object.
+        :returns:
+            The created object.
+        """
+        data["role"] = ChatRole(data["role"])
+
+        # deserialize tool_calls
+        if tool_calls := data.get("tool_calls"):
+            data["tool_calls"] = [ToolCall(**tool_call) for tool_call in tool_calls]
+
+        return cls(**data)

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -26,7 +26,7 @@ class ToolCall:
     :param arguments: The arguments to call the Tool with.
     """
 
-    id: str
+    id: str  # ignore
     tool_name: str
     arguments: Dict[str, Any]
 

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -10,17 +10,18 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 class ChatRole(str, Enum):
     """
     Enumeration representing the roles within a chat.
-
-    - `USER`: The user role. A message from the user contains only text.
-    - `SYSTEM`: The system role. A message from the system contains only text.
-    - `ASSISTANT`: The assistant role. A message from the assistant can contain text and prepared Tool calls.
-        It can also store additional metadata.
-    - `TOOL`: The tool role. A message from a tool contains the result of a Tool invocation.
     """
 
+    #: The user role. A message from the user contains only text.
     USER = "user"
+
+    #: The system role. A message from the system contains only text.
     SYSTEM = "system"
+
+    #: The assistant role. A message from the assistant can contain text and Tool calls. It can also store metadata.
     ASSISTANT = "assistant"
+
+    #: The tool role. A message from a tool contains the result of a Tool invocation.
     TOOL = "tool"
 
 

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -231,7 +231,7 @@ class ChatMessage:
             elif isinstance(part, ToolCallResult):
                 content.append({"tool_call_result": asdict(part)})
             else:
-                raise TypeError(f"Unsupported type `{type(part).__name__}` for `{part}`.")
+                raise TypeError(f"Unsupported type in ChatMessage content: `{type(part).__name__}` for `{part}`.")
 
         serialized["_content"] = content
         return serialized
@@ -256,9 +256,12 @@ class ChatMessage:
             elif "tool_call" in part:
                 content.append(ToolCall(**part["tool_call"]))
             elif "tool_call_result" in part:
-                content.append(ToolCallResult(**part["tool_call_result"]))
+                result = part["tool_call_result"]["result"]
+                origin = ToolCall(**part["tool_call_result"]["origin"])
+                tcr = ToolCallResult(result=result, origin=origin)
+                content.append(tcr)
             else:
-                raise TypeError(f"Unsupported type `{type(part).__name__}` for `{part}`.")
+                raise ValueError(f"Unsupported content in serialized ChatMessage: `{part}`")
 
         data["_content"] = content
 

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -26,7 +26,7 @@ class ToolCall:
     :param arguments: The arguments to call the Tool with.
     """
 
-    id: str  # ignore
+    id: str  # noqa: A003
     tool_name: str
     arguments: Dict[str, Any]
 

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -171,7 +171,7 @@ class ChatMessage:
     def from_assistant(
         cls,
         text: Optional[str] = None,
-        tool_calls: Optional[Sequence[ToolCall]] = None,
+        tool_calls: Optional[List[ToolCall]] = None,
         meta: Optional[Dict[str, Any]] = None,
     ) -> "ChatMessage":
         """

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -183,7 +183,7 @@ class ChatMessage:
         :returns: A new ChatMessage instance.
         """
         if not text and not tool_calls:
-            raise ValueError("At least one of 'text' or 'tool_calls' must be provided.")
+            raise ValueError("At least one of `text` or `tool_calls` must be provided.")
 
         content: List[ChatMessageContentT] = []
         if text:

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from haystack_experimental.dataclasses import ChatMessage, ChatRole, ToolCall
+
+def test_tool_call_init():
+    tc = ToolCall(id="123", tool_name="mytool", arguments={"a": 1})
+    assert tc.id == "123"
+    assert tc.tool_name == "mytool"
+    assert tc.arguments == {"a": 1}
+
+def test_from_assistant_with_valid_content():
+    content = "Hello, how can I assist you?"
+    message = ChatMessage.from_assistant(content)
+    assert message.content == content
+    assert message.role == ChatRole.ASSISTANT
+
+def test_from_assistant_with_tool_calls():
+    content =""
+    tool_calls = [ToolCall(id="123", tool_name="mytool", arguments={"a": 1}),
+                  ToolCall(id="456", tool_name="mytool2", arguments={"b": 2})]
+
+    message = ChatMessage.from_assistant(content=content, tool_calls=tool_calls)
+
+    assert message.role == ChatRole.ASSISTANT
+    assert message.content == content
+    assert message.tool_calls == tool_calls
+
+
+def test_from_user_with_valid_content():
+    content = "I have a question."
+    message = ChatMessage.from_user(content)
+    assert message.content == content
+    assert message.role == ChatRole.USER
+
+
+def test_from_system_with_valid_content():
+    content = "System message."
+    message = ChatMessage.from_system(content)
+    assert message.content == content
+    assert message.role == ChatRole.SYSTEM
+
+def test_from_tool_with_valid_content():
+    content = "Tool message."
+    tool_call_id = "123"
+    message = ChatMessage.from_tool(content, tool_call_id)
+
+    assert message.content == content
+    assert message.role == ChatRole.TOOL
+    assert message.tool_call_id == tool_call_id
+
+
+def test_with_empty_content():
+    message = ChatMessage.from_user("")
+    assert message.content == ""
+
+
+def test_to_dict():
+    message = ChatMessage.from_user("content")
+    message.meta["some"] = "some"
+
+    assert message.to_dict() == {'content': 'content', 'role': 'user', 'tool_call_id': None, 'tool_calls': [], 'meta': {'some': 'some'}}
+
+
+def test_from_dict():
+    assert ChatMessage.from_dict(data={"content": "text", "role": "user"}) == ChatMessage.from_user(content="text")
+
+
+def test_from_dict_with_meta():
+    assert ChatMessage.from_dict(
+        data={"content": "text", "role": "assistant", "meta": {"something": "something"}}
+    ) == ChatMessage.from_assistant(content="text", meta={"something": "something"})
+
+def test_serde_with_tool_calls():
+    tool_call = ToolCall(id="123", tool_name="tool", arguments={"a": 1})
+    message = ChatMessage.from_assistant("a message", tool_calls=[tool_call])
+
+    serialized_message = message.to_dict()
+
+    assert serialized_message=={'content': 'a message', 'role': 'assistant', 'tool_call_id': None, 'tool_calls': [{'id': '123', 'tool_name': 'tool', 'arguments': {'a': 1}}], 'meta': {}}
+
+    deserialized_message = ChatMessage.from_dict(serialized_message)
+    assert deserialized_message == message


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8136

### Proposed Changes:
I'm overriding the whole module. However, I'm trying not to deviate much from the current implementation...

Notable changes:
- introduce `ToolCall` dataclass to represent a Tool call prepared by the model
- introduce `tool` role for messages containing the results of (external) tool invocations
- drop the support for `function` role (deprecated by OpenAI): I think supporting it properly is not worth it (the world is moving away from this style/mode of doing things). In truth, I would also deprecate it in the Haystack core.


### How did you test it?
Adapted old tests, new tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
