### PR TITLE
chore: Disable meteo openapi tests

### DIFF
--- a/test/components/tools/openapi/test_openapi_tool.py
+++ b/test/components/tools/openapi/test_openapi_tool.py
@@ -204,6 +204,7 @@ class TestOpenAPITool:
 
     @pytest.mark.integration
     @pytest.mark.parametrize("provider", ["openai", "anthropic", "cohere"])
+    @pytest.mark.skip(reason="Underlying service gets overloaded often")
     def test_run_live_meteo_forecast(self, provider: str):
         tool = OpenAPITool(
             generator_api=LLMProvider.from_str(provider),


### PR DESCRIPTION
Disabling unit test for meteo openapi tests, underlying service often overloaded