### PR TITLE
feat: Add unstable marker, mark unstable tests, skip them in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration and not unstable" {args:test}'
-integration = 'pytest --reruns 3 --reruns-delay 60 -x --maxfail=5 -m "integration and not unstable" {args:test}'
+unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration" {args:test}'
+integration = 'pytest --reruns 3 --reruns-delay 60 -x --maxfail=5 -m "integration" {args:test}'
 typing = "mypy --install-types --non-interactive {args:haystack_experimental}"
 lint = [
   "ruff check {args:haystack_experimental}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration" {args:test}'
-integration = 'pytest --reruns 3 --reruns-delay 60 -x --maxfail=5 -m "integration" {args:test}'
+unit = 'pytest --cov-report xml:coverage.xml --cov="haystack_experimental" -m "not integration and not unstable" {args:test}'
+integration = 'pytest --reruns 3 --reruns-delay 60 -x --maxfail=5 -m "integration and not unstable" {args:test}'
 typing = "mypy --install-types --non-interactive {args:haystack_experimental}"
 lint = [
   "ruff check {args:haystack_experimental}",
@@ -155,7 +155,10 @@ disable = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--strict-markers"
-markers = ["integration: integration tests"]
+markers = [
+  "integration: integration tests",
+  "unstable(reason): Mark tests that are unstable or depend on unreliable services."
+]
 log_cli = true
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ lint = [
   "ruff check {args:haystack_experimental}",
   "pylint -ry -j 0 {args:haystack_experimental}",
 ]
-test-cov = "coverage run -m pytest {args:test}"
+test-cov = "coverage run -m pytest -m 'not unstable' {args:test}"
 cov-report = ["- coverage combine", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ lint = [
   "ruff check {args:haystack_experimental}",
   "pylint -ry -j 0 {args:haystack_experimental}",
 ]
-test-cov = "coverage run -m pytest -m 'not unstable' {args:test}"
+test-cov = "coverage run -m pytest -m \"not unstable\" {args:test}"
 cov-report = ["- coverage combine", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 

--- a/test/components/tools/openapi/test_openapi_client_live.py
+++ b/test/components/tools/openapi/test_openapi_client_live.py
@@ -30,7 +30,7 @@ class TestClientLive:
         assert "invention" in str(response)
 
     @pytest.mark.integration
-    @pytest.mark.skip("This test hits rate limit on Github API. Skip for now.")
+    @pytest.mark.unstable("This test hits rate limit on Github API.")
     def test_github(self, test_files_path):
         config = ClientConfiguration(openapi_spec=create_openapi_spec(test_files_path / "yaml" / "github_compare.yml"))
         api = OpenAPIServiceClient(config)

--- a/test/components/tools/openapi/test_openapi_client_live_anthropic.py
+++ b/test/components/tools/openapi/test_openapi_client_live_anthropic.py
@@ -41,7 +41,7 @@ class TestClientLiveAnthropic:
 
     @pytest.mark.skipif("ANTHROPIC_API_KEY" not in os.environ, reason="ANTHROPIC_API_KEY not set")
     @pytest.mark.integration
-    @pytest.mark.skip("This test hits rate limit on Github API. Skip for now.")
+    @pytest.mark.unstable("This test hits rate limit on Github API.")
     def test_github(self, test_files_path):
         config = ClientConfiguration(openapi_spec=create_openapi_spec(test_files_path / "yaml" / "github_compare.yml"),
                                      llm_provider=LLMProvider.ANTHROPIC)

--- a/test/components/tools/openapi/test_openapi_client_live_cohere.py
+++ b/test/components/tools/openapi/test_openapi_client_live_cohere.py
@@ -53,7 +53,7 @@ class TestClientLiveCohere:
 
     @pytest.mark.skipif("COHERE_API_KEY" not in os.environ, reason="COHERE_API_KEY not set")
     @pytest.mark.integration
-    @pytest.mark.skip("This test hits rate limit on Github API. Skip for now.")
+    @pytest.mark.unstable("This test hits rate limit on Github API.")
     def test_github(self, test_files_path):
         config = ClientConfiguration(openapi_spec=create_openapi_spec(test_files_path / "yaml" / "github_compare.yml"),
                                      llm_provider=LLMProvider.COHERE)

--- a/test/components/tools/openapi/test_openapi_client_live_openai.py
+++ b/test/components/tools/openapi/test_openapi_client_live_openai.py
@@ -39,7 +39,7 @@ class TestClientLiveOpenAPI:
 
     @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
-    @pytest.mark.skip("This test hits rate limit on Github API. Skip for now.")
+    @pytest.mark.unstable("This test hits rate limit on Github API.")
     def test_github(self, test_files_path):
         config = ClientConfiguration(openapi_spec=create_openapi_spec(test_files_path / "yaml" / "github_compare.yml"))
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -61,7 +61,7 @@ class TestClientLiveOpenAPI:
     @pytest.mark.skipif("FIRECRAWL_API_KEY" not in os.environ, reason="FIRECRAWL_API_KEY not set")
     @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
-    @pytest.mark.skip("This test is flaky likely due to load on the popular Firecrawl API. Skip for now.")
+    @pytest.mark.unstable("This test is flaky likely due to load on the popular Firecrawl API")
     def test_firecrawl(self):
         openapi_spec_url = "https://raw.githubusercontent.com/mendableai/firecrawl/main/apps/api/openapi.json"
         config = ClientConfiguration(openapi_spec=create_openapi_spec(openapi_spec_url), credentials=os.getenv("FIRECRAWL_API_KEY"))

--- a/test/components/tools/openapi/test_openapi_tool.py
+++ b/test/components/tools/openapi/test_openapi_tool.py
@@ -204,6 +204,7 @@ class TestOpenAPITool:
 
     @pytest.mark.integration
     @pytest.mark.parametrize("provider", ["openai", "anthropic", "cohere"])
+    @pytest.mark.unstable("This test can be unstable due to free meteo service being down")
     def test_run_live_meteo_forecast(self, provider: str):
         tool = OpenAPITool(
             generator_api=LLMProvider.from_str(provider),


### PR DESCRIPTION
- Add new marker for tests `unstable`
- Mark all unstable tests and reasons why they fail
- Skip these tests in CI by default
- Run them from command line if needed with:
    - `hatch run test:integration -- -m "integration and unstable"` 
    
Supersedes https://github.com/deepset-ai/haystack-experimental/pull/54    