### PR TITLE
fix: `OpenAPITool` - use keyword args for chat generator run invocation

### DIFF
--- a/haystack_experimental/components/tools/openapi/openapi_tool.py
+++ b/haystack_experimental/components/tools/openapi/openapi_tool.py
@@ -158,7 +158,7 @@ class OpenAPITool:
             "Invoking chat generator with {message} to generate function calling payload.",
             message=last_message.content,
         )
-        fc_payload = self.chat_generator.run(messages, fc_generator_kwargs)
+        fc_payload = self.chat_generator.run(messages, generation_kwargs=fc_generator_kwargs)
         try:
             invocation_payload = json.loads(fc_payload["replies"][0].content)
             logger.debug("Invoking tool with {payload}", payload=invocation_payload)


### PR DESCRIPTION
In the main haystack project pull request [8054](https://github.com/deepset-ai/haystack/pull/8054) added a new parameter in chat generator run methods.

Since we didn't use keyword arguments in invocation of the run method of the chat generator in [`openapi_tool.py`](https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/tools/openapi/openapi_tool.py#L161) we need to now use keyword arguments.