### PR TITLE
docs: add pydoc configs for `Tool` and `OpenAIChatGenerator`

### DIFF
--- a/docs/pydoc/config/generators_api.yml
+++ b/docs/pydoc/config/generators_api.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../]
-    modules: ["haystack_experimental.dataclasses.chat_message", "haystack_experimental.dataclasses.tool"]
+    modules: ["haystack_experimental.components.generators.chat.openai"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -13,15 +13,15 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
-  excerpt: Core classes that carry data through the system.
+  excerpt: Enables text generation using LLMs.
   category_slug: experiments-api
-  title: Data Classes
-  slug: data-classes-api
-  order: 30
+  title: Generators
+  slug: generators-api
+  order: 70
   markdown:
     descriptive_class_title: false
     classdef_code_block: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: data_classess_api.md
+    filename: generators_api.md


### PR DESCRIPTION
### Proposed Changes

Add missing pydoc configs for classes added in #53 and #57


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
