### PR TITLE
feat: Adds `last_k` parameter to `ChatMessageRetriever` init/run methods

### DIFF
--- a/haystack_experimental/components/retrievers/chat_message_retriever.py
+++ b/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -46,7 +46,7 @@ class ChatMessageRetriever:
         :param message_store:
             An instance of a ChatMessageStore.
         :param top_k:
-            The number of messages to retrieve.
+            The number of messages to retrieve. Defaults to 10 messages if not specified.
         """
         self.message_store = message_store
         if top_k <= 0:
@@ -93,7 +93,9 @@ class ChatMessageRetriever:
         """
         Run the ChatMessageRetriever
 
-        :param top_k: The number of messages to retrieve. If None all messages will be retrieved.
+        :param top_k: The number of messages to retrieve. This parameter takes precedence over the top_k parameter
+            passed to the ChatMessageRetriever constructor. If unspecified, the top_k parameter passed to the
+            constructor will be used.
         :returns:
             - `messages` - The retrieved chat messages.
         :raises ValueError: If top_k is not None and is less than 1

--- a/haystack_experimental/components/retrievers/chat_message_retriever.py
+++ b/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -39,14 +39,19 @@ class ChatMessageRetriever:
     ```
     """
 
-    def __init__(self, message_store: ChatMessageStore):
+    def __init__(self, message_store: ChatMessageStore, top_k: int = 10):
         """
         Create the ChatMessageRetriever component.
 
         :param message_store:
             An instance of a ChatMessageStore.
+        :param top_k:
+            The number of messages to retrieve.
         """
         self.message_store = message_store
+        if top_k <= 0:
+            raise ValueError(f"top_k must be greater than 0. Currently, the top_k is {top_k}")
+        self.top_k = top_k
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -56,7 +61,7 @@ class ChatMessageRetriever:
             Dictionary with serialized data.
         """
         message_store = self.message_store.to_dict()
-        return default_to_dict(self, message_store=message_store)
+        return default_to_dict(self, message_store=message_store, top_k=self.top_k)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChatMessageRetriever":
@@ -95,5 +100,7 @@ class ChatMessageRetriever:
         """
         if top_k is not None and top_k <= 0:
             raise ValueError("top_k must be greater than 0")
+
+        top_k = top_k or self.top_k
 
         return {"messages": self.message_store.retrieve()[-top_k:]}

--- a/haystack_experimental/components/retrievers/chat_message_retriever.py
+++ b/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -39,19 +39,19 @@ class ChatMessageRetriever:
     ```
     """
 
-    def __init__(self, message_store: ChatMessageStore, top_k: int = 10):
+    def __init__(self, message_store: ChatMessageStore, last_k: int = 10):
         """
         Create the ChatMessageRetriever component.
 
         :param message_store:
             An instance of a ChatMessageStore.
-        :param top_k:
-            The number of messages to retrieve. Defaults to 10 messages if not specified.
+        :param last_k:
+            The number of last messages to retrieve. Defaults to 10 messages if not specified.
         """
         self.message_store = message_store
-        if top_k <= 0:
-            raise ValueError(f"top_k must be greater than 0. Currently, the top_k is {top_k}")
-        self.top_k = top_k
+        if last_k <= 0:
+            raise ValueError(f"last_k must be greater than 0. Currently, the last_k is {last_k}")
+        self.last_k = last_k
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -61,7 +61,7 @@ class ChatMessageRetriever:
             Dictionary with serialized data.
         """
         message_store = self.message_store.to_dict()
-        return default_to_dict(self, message_store=message_store, top_k=self.top_k)
+        return default_to_dict(self, message_store=message_store, last_k=self.last_k)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChatMessageRetriever":
@@ -89,20 +89,20 @@ class ChatMessageRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(messages=List[ChatMessage])
-    def run(self, top_k: Optional[int] = None):
+    def run(self, last_k: Optional[int] = None):
         """
         Run the ChatMessageRetriever
 
-        :param top_k: The number of messages to retrieve. This parameter takes precedence over the top_k parameter
-            passed to the ChatMessageRetriever constructor. If unspecified, the top_k parameter passed to the
-            constructor will be used.
+        :param last_k: The number of last messages to retrieve. This parameter takes precedence over the last_k
+            parameter passed to the ChatMessageRetriever constructor. If unspecified, the last_k parameter passed
+            to the constructor will be used.
         :returns:
             - `messages` - The retrieved chat messages.
-        :raises ValueError: If top_k is not None and is less than 1
+        :raises ValueError: If last_k is not None and is less than 1
         """
-        if top_k is not None and top_k <= 0:
-            raise ValueError("top_k must be greater than 0")
+        if last_k is not None and last_k <= 0:
+            raise ValueError("last_k must be greater than 0")
 
-        top_k = top_k or self.top_k
+        last_k = last_k or self.last_k
 
-        return {"messages": self.message_store.retrieve()[-top_k:]}
+        return {"messages": self.message_store.retrieve()[-last_k:]}

--- a/haystack_experimental/components/retrievers/chat_message_retriever.py
+++ b/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from haystack import DeserializationError, component, default_from_dict, default_to_dict, logging
 from haystack.core.serialization import import_class_by_name
@@ -84,11 +84,16 @@ class ChatMessageRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(messages=List[ChatMessage])
-    def run(self):
+    def run(self, top_k: Optional[int] = None):
         """
         Run the ChatMessageRetriever
 
+        :param top_k: The number of messages to retrieve. If None all messages will be retrieved.
         :returns:
             - `messages` - The retrieved chat messages.
+        :raises ValueError: If top_k is not None and is less than 1
         """
-        return {"messages": self.message_store.retrieve()}
+        if top_k is not None and top_k <= 0:
+            raise ValueError("top_k must be greater than 0")
+
+        return {"messages": self.message_store.retrieve()[-top_k:]}

--- a/test/components/retrievers/test_chat_message_retriever.py
+++ b/test/components/retrievers/test_chat_message_retriever.py
@@ -35,9 +35,9 @@ class TestChatMessageRetriever:
         assert retriever.message_store == message_store
         assert retriever.run() == {"messages": messages}
 
-    def test_retrieve_messages_topk(self):
+    def test_retrieve_messages_last_k(self):
         """
-        Test that the ChatMessageRetriever component can retrieve top_k messages from the message store.
+        Test that the ChatMessageRetriever component can retrieve last_k messages from the message store.
         """
         messages = [
             ChatMessage.from_user(content="Hello, how can I help you?"),
@@ -51,16 +51,16 @@ class TestChatMessageRetriever:
         retriever = ChatMessageRetriever(message_store)
 
         assert retriever.message_store == message_store
-        assert retriever.run(top_k=1) == {
+        assert retriever.run(last_k=1) == {
             "messages": [ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")]}
 
-        assert retriever.run(top_k=2) == {
+        assert retriever.run(last_k=2) == {
             "messages": [ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
                          ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
                          ]}
 
         # outliers
-        assert retriever.run(top_k=10) == {
+        assert retriever.run(last_k=10) == {
             "messages": [ChatMessage.from_user(content="Hello, how can I help you?"),
                          ChatMessage.from_user(content="Hallo, wie kann ich Ihnen helfen?"),
                          ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
@@ -68,15 +68,15 @@ class TestChatMessageRetriever:
                          ]}
 
         with pytest.raises(ValueError):
-            retriever.run(top_k=0)
+            retriever.run(last_k=0)
 
         with pytest.raises(ValueError):
-            retriever.run(top_k=-1)
+            retriever.run(last_k=-1)
 
-    def test_retrieve_messages_topk_init(self):
+    def test_retrieve_messages_last_k_init(self):
         """
-        Test that the ChatMessageRetriever component can retrieve top_k messages from the message store
-        by testing the init top_k parameter and the run top_k parameter logic
+        Test that the ChatMessageRetriever component can retrieve last_k messages from the message store
+        by testing the init last_k parameter and the run last_k parameter logic
         """
         messages = [
             ChatMessage.from_user(content="Hello, how can I help you?"),
@@ -87,15 +87,15 @@ class TestChatMessageRetriever:
 
         message_store = InMemoryChatMessageStore()
         message_store.write_messages(messages)
-        retriever = ChatMessageRetriever(message_store, top_k=2)
+        retriever = ChatMessageRetriever(message_store, last_k=2)
 
         assert retriever.message_store == message_store
 
-        # top_k is 1 here from run parameter, overrides init of 2
-        assert retriever.run(top_k=1) == {
+        # last_k is 1 here from run parameter, overrides init of 2
+        assert retriever.run(last_k=1) == {
             "messages": [ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")]}
 
-        # top_k is 2 here from init
+        # last_k is 2 here from init
         assert retriever.run() == {
             "messages": [ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
                          ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
@@ -106,7 +106,7 @@ class TestChatMessageRetriever:
         Test that the ChatMessageRetriever component can be serialized to a dictionary.
         """
         message_store = InMemoryChatMessageStore()
-        retriever = ChatMessageRetriever(message_store, top_k=4)
+        retriever = ChatMessageRetriever(message_store, last_k=4)
 
         data = retriever.to_dict()
         assert data == {
@@ -116,7 +116,7 @@ class TestChatMessageRetriever:
                     "init_parameters": {},
                     "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
                 },
-                "top_k": 4,
+                "last_k": 4,
             },
         }
 
@@ -131,7 +131,7 @@ class TestChatMessageRetriever:
                     "init_parameters": {},
                     "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
                 },
-                "top_k": 4,
+                "last_k": 4,
             },
         }
         retriever = ChatMessageRetriever.from_dict(data)
@@ -139,7 +139,7 @@ class TestChatMessageRetriever:
             "init_parameters": {},
             "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
         }
-        assert retriever.top_k == 4
+        assert retriever.last_k == 4
 
     def test_chat_message_retriever_pipeline(self):
         """

--- a/test/components/retrievers/test_chat_message_retriever.py
+++ b/test/components/retrievers/test_chat_message_retriever.py
@@ -78,7 +78,7 @@ class TestChatMessageRetriever:
         Test that the ChatMessageRetriever component can be serialized to a dictionary.
         """
         message_store = InMemoryChatMessageStore()
-        retriever = ChatMessageRetriever(message_store)
+        retriever = ChatMessageRetriever(message_store, top_k=4)
 
         data = retriever.to_dict()
         assert data == {
@@ -87,7 +87,8 @@ class TestChatMessageRetriever:
                 "message_store": {
                     "init_parameters": {},
                     "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
-                }
+                },
+                "top_k": 4,
             },
         }
 
@@ -101,7 +102,8 @@ class TestChatMessageRetriever:
                 "message_store": {
                     "init_parameters": {},
                     "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
-                }
+                },
+                "top_k": 4,
             },
         }
         retriever = ChatMessageRetriever.from_dict(data)
@@ -109,6 +111,7 @@ class TestChatMessageRetriever:
             "init_parameters": {},
             "type": "haystack_experimental.chat_message_stores.in_memory.InMemoryChatMessageStore"
         }
+        assert retriever.top_k == 4
 
     def test_chat_message_retriever_pipeline(self):
         """

--- a/test/components/retrievers/test_chat_message_retriever.py
+++ b/test/components/retrievers/test_chat_message_retriever.py
@@ -73,6 +73,34 @@ class TestChatMessageRetriever:
         with pytest.raises(ValueError):
             retriever.run(top_k=-1)
 
+    def test_retrieve_messages_topk_init(self):
+        """
+        Test that the ChatMessageRetriever component can retrieve top_k messages from the message store
+        by testing the init top_k parameter and the run top_k parameter logic
+        """
+        messages = [
+            ChatMessage.from_user(content="Hello, how can I help you?"),
+            ChatMessage.from_user(content="Hallo, wie kann ich Ihnen helfen?"),
+            ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
+            ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
+        ]
+
+        message_store = InMemoryChatMessageStore()
+        message_store.write_messages(messages)
+        retriever = ChatMessageRetriever(message_store, top_k=2)
+
+        assert retriever.message_store == message_store
+
+        # top_k is 1 here from run parameter, overrides init of 2
+        assert retriever.run(top_k=1) == {
+            "messages": [ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")]}
+
+        # top_k is 2 here from init
+        assert retriever.run() == {
+            "messages": [ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
+                         ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
+                         ]}
+
     def test_to_dict(self):
         """
         Test that the ChatMessageRetriever component can be serialized to a dictionary.


### PR DESCRIPTION
### Why:
Enhances the `ChatMessageRetriever` component by introducing a `last_k` parameter allowing for selective retrieval of a specified number of recent chat messages. This change addresses the need for more control in accessing chat history, particularly in scenarios where only the most recent interactions are relevant.

- fixes https://github.com/deepset-ai/haystack/issues/8258

### What:
- Added `last_k` as init parameter to match the existing pattern in other retrievers (defaults to 10)
- Added an `Optional[int]` parameter named `last_k` to the `run` method of the `ChatMessageRetriever`, enabling selection of the number of recent messages to retrieve.
- Implemented validation to ensure `last_k` is greater than 0 when specified, raising a `ValueError` if not.
- Expanded unit tests to cover new functionalities, including cases where `last_k` is specified, and edge cases where `last_k` is set to 0 or a negative number, ensuring robustness through comprehensive testing.

### How can it be used:
```python
from haystack import Pipeline
from haystack.components.builders import ChatPromptBuilder
from haystack.dataclasses import ChatMessage

from haystack_experimental.components.retrievers import ChatMessageRetriever
from haystack_experimental.chat_message_stores.in_memory import InMemoryChatMessageStore

messages = [
            ChatMessage.from_user(content="Hello, how can I help you?"),
            ChatMessage.from_user(content="Hallo, wie kann ich Ihnen helfen?"),
            ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
            ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
        ]

        message_store = InMemoryChatMessageStore()
        message_store.write_messages(messages)
        retriever = ChatMessageRetriever(message_store)

assert retriever.run(last_k=2) == {
            "messages": [ChatMessage.from_user(content="Hola, como puedo ayudarte?"),
                         ChatMessage.from_user(content="Bonjour, comment puis-je vous aider?")
                         ]}
```
### How did you test it:
- Unit tests were written to verify the correct retrieval of messages when a valid `last_k` value is provided.
- Tests ensure correct behavior when `last_k` exceeds the number of available messages, in which case all messages should be returned.
- Edge cases where `last_k` is set to 0 or a negative number were tested to confirm that a `ValueError` is appropriately raised.


### Notes for the reviewer:
- We first used `top_k` as the name for this parameter but have since renamed it to `last_k`. See https://github.com/deepset-ai/haystack/issues/8258 for further discussion