### PR TITLE
chore: `AutoMergingRetriever` - use `deserialize_document_store_in_init_params_inplace` 

### DIFF
--- a/haystack_experimental/components/retrievers/auto_merging_retriever.py
+++ b/haystack_experimental/components/retrievers/auto_merging_retriever.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 from haystack import Document, component, default_to_dict
 from haystack.core.serialization import default_from_dict
 from haystack.document_stores.types import DocumentStore
-from haystack.utils import deserialize_document_store_in_init_parameters
+from haystack.utils import deserialize_document_store_in_init_params_inplace
 
 
 @component
@@ -96,7 +96,7 @@ class AutoMergingRetriever:
         :returns:
             An instance of the component.
         """
-        data = deserialize_document_store_in_init_parameters(data)
+        deserialize_document_store_in_init_params_inplace(data)
         return default_from_dict(cls, data)
 
     @staticmethod


### PR DESCRIPTION
### Related Issues

`deserialize_document_store_in_init_parameters` was renamed to `deserialize_document_store_in_init_params_inplace` in https://github.com/deepset-ai/haystack/pull/8302.

This change will be included in the upcoming `haystack-ai` 2.5.0 release.

### Proposed Changes:
- adopt the new utility function

### How did you test it?
CI

### Notes for the reviewer
Tests are expected to fail now.
This change should be integrated after the `haystack-ai` 2.5.0 release.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
