### PR TITLE
feat: Implement async support for `OpenAIChatGenerator`

### DIFF
--- a/haystack_experimental/components/generators/chat/openai.py
+++ b/haystack_experimental/components/generators/chat/openai.py
@@ -3,19 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Any, Callable, Dict, List, Optional, Union
+import os
+from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, logging
-from haystack.components.generators.chat.openai import OpenAIChatGenerator as OpenAIChatGeneratorBase
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import StreamingChunk
-from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace
-from openai import Stream
+from haystack.utils import (
+    Secret,
+    deserialize_callable,
+    deserialize_secrets_inplace,
+    serialize_callable,
+)
+from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
-from haystack_experimental.dataclasses import ChatMessage, ToolCall
-from haystack_experimental.dataclasses.tool import Tool, deserialize_tools_inplace
+from haystack_experimental.dataclasses import ChatMessage, Tool, ToolCall
+from haystack_experimental.dataclasses.streaming_chunk import (
+    AsyncStreamingCallbackT,
+    StreamingCallbackT,
+    select_streaming_callback,
+)
+from haystack_experimental.dataclasses.tool import deserialize_tools_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -29,16 +39,22 @@ def _convert_message_to_openai_format(message: ChatMessage) -> Dict[str, Any]:
     tool_call_results = message.tool_call_results
 
     if not text_contents and not tool_calls and not tool_call_results:
-        raise ValueError("A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, or `ToolCallResult`.")
+        raise ValueError(
+            "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, or `ToolCallResult`."
+        )
     elif len(text_contents) + len(tool_call_results) > 1:
-        raise ValueError("A `ChatMessage` can only contain one `TextContent` or one `ToolCallResult`.")
+        raise ValueError(
+            "A `ChatMessage` can only contain one `TextContent` or one `ToolCallResult`."
+        )
 
     openai_msg: Dict[str, Any] = {"role": message._role.value}
 
     if tool_call_results:
         result = tool_call_results[0]
         if result.origin.id is None:
-            raise ValueError("`ToolCall` must have a non-null `id` attribute to be used with OpenAI.")
+            raise ValueError(
+                "`ToolCall` must have a non-null `id` attribute to be used with OpenAI."
+            )
         openai_msg["content"] = result.result
         openai_msg["tool_call_id"] = result.origin.id
         # OpenAI does not provide a way to communicate errors in tool invocations, so we ignore the error field
@@ -50,12 +66,17 @@ def _convert_message_to_openai_format(message: ChatMessage) -> Dict[str, Any]:
         openai_tool_calls = []
         for tc in tool_calls:
             if tc.id is None:
-                raise ValueError("`ToolCall` must have a non-null `id` attribute to be used with OpenAI.")
+                raise ValueError(
+                    "`ToolCall` must have a non-null `id` attribute to be used with OpenAI."
+                )
             openai_tool_calls.append(
                 {
                     "id": tc.id,
                     "type": "function",
-                    "function": {"name": tc.tool_name, "arguments": json.dumps(tc.arguments)},
+                    "function": {
+                        "name": tc.tool_name,
+                        "arguments": json.dumps(tc.arguments),
+                    },
                 }
             )
         openai_msg["tool_calls"] = openai_tool_calls
@@ -63,7 +84,7 @@ def _convert_message_to_openai_format(message: ChatMessage) -> Dict[str, Any]:
 
 
 @component
-class OpenAIChatGenerator(OpenAIChatGeneratorBase):
+class OpenAIChatGenerator:
     """
     Completes chats using OpenAI's large language models (LLMs).
 
@@ -107,8 +128,10 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
     def __init__(  # noqa: PLR0913
         self,
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
-        model: str = "gpt-3.5-turbo",
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        model: str = "gpt-4o-mini",
+        streaming_callback: Optional[
+            Union[StreamingCallbackT, AsyncStreamingCallbackT]
+        ] = None,
         api_base_url: Optional[str] = None,
         organization: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
@@ -118,25 +141,23 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         tools_strict: bool = False,
     ):
         """
-        Creates an instance of OpenAIChatGenerator. Unless specified otherwise in `model`, uses OpenAI's GPT-3.5.
+        Creates an instance of OpenAIChatGenerator.
 
-        Before initializing the component, you can set the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES'
-        environment variables to override the `timeout` and `max_retries` parameters respectively
-        in the OpenAI client.
-
-        :param api_key: The OpenAI API key.
-            You can set it with an environment variable `OPENAI_API_KEY`, or pass with this parameter
-            during initialization.
-        :param model: The name of the model to use.
-        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param api_key:
+            The OpenAI API key.
+        :param model:
+            The name of the model to use.
+        :param streaming_callback:
+            A callback function that is called when a new token is received from the stream.
             The callback function accepts [StreamingChunk](https://docs.haystack.deepset.ai/docs/data-classes#streamingchunk)
-            as an argument.
-        :param api_base_url: An optional base URL.
-        :param organization: Your organization ID, defaults to `None`. See
-        [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
-        :param generation_kwargs: Other parameters to use for the model. These parameters are sent directly to
-            the OpenAI endpoint. See OpenAI [documentation](https://platform.openai.com/docs/api-reference/chat) for
-            more details.
+            as an argument. Must be a coroutine if the component is used in an async pipeline.
+        :param api_base_url:
+            An optional base URL.
+        :param organization:
+            Your organization ID. See [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
+        :param generation_kwargs:
+            Other parameters to use for the model. These parameters are sent directly to the OpenAI endpoint.
+            See OpenAI [documentation](https://platform.openai.com/docs/api-reference/chat) for more details.
             Some of the supported parameters:
             - `max_tokens`: The maximum number of tokens the output text can have.
             - `temperature`: What sampling temperature to use. Higher values mean the model will take more risks.
@@ -165,21 +186,35 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
             Whether to enable strict schema adherence for tool calls. If set to `True`, the model will follow exactly
             the schema provided in the `parameters` field of the tool definition, but this may increase latency.
         """
-        if tools:
-            tool_names = [tool.name for tool in tools]
-            duplicate_tool_names = {name for name in tool_names if tool_names.count(name) > 1}
-            if duplicate_tool_names:
-                raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
+        self.api_key = api_key
+        self.model = model
+        self.generation_kwargs = generation_kwargs or {}
+        self.streaming_callback = streaming_callback
+        self.api_base_url = api_base_url
+        self.organization = organization
+        self.timeout = timeout
+        self.max_retries = max_retries
         self.tools = tools
         self.tools_strict = tools_strict
 
-        super(OpenAIChatGenerator, self).__init__(
-            api_key=api_key,
-            model=model,
-            streaming_callback=streaming_callback,
-            api_base_url=api_base_url,
+        self._validate_tools(tools)
+
+        if timeout is None:
+            timeout = float(os.environ.get("OPENAI_TIMEOUT", 30.0))
+        if max_retries is None:
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", 5))
+
+        self.client = OpenAI(
+            api_key=api_key.resolve_value(),
             organization=organization,
-            generation_kwargs=generation_kwargs,
+            base_url=api_base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key.resolve_value(),
+            organization=organization,
+            base_url=api_base_url,
             timeout=timeout,
             max_retries=max_retries,
         )
@@ -191,17 +226,32 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         :returns:
             The serialized component as a dictionary.
         """
-        serialized = super(OpenAIChatGenerator, self).to_dict()
-        serialized["init_parameters"]["tools"] = [tool.to_dict() for tool in self.tools] if self.tools else None
-        serialized["init_parameters"]["tools_strict"] = self.tools_strict
-        return serialized
+        callback_name = (
+            serialize_callable(self.streaming_callback)
+            if self.streaming_callback
+            else None
+        )
+        return default_to_dict(
+            self,
+            model=self.model,
+            streaming_callback=callback_name,
+            api_base_url=self.api_base_url,
+            organization=self.organization,
+            generation_kwargs=self.generation_kwargs,
+            api_key=self.api_key.to_dict(),
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            tools=[tool.to_dict() for tool in self.tools] if self.tools else None,
+            tools_strict=self.tools_strict,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "OpenAIChatGenerator":
         """
         Deserialize this component from a dictionary.
 
-        :param data: The dictionary representation of this component.
+        :param data:
+            The dictionary representation of this component.
         :returns:
             The deserialized component instance.
         """
@@ -210,7 +260,9 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
-            data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
+            data["init_parameters"]["streaming_callback"] = deserialize_callable(
+                serialized_callback_handler
+            )
 
         return default_from_dict(cls, data)
 
@@ -218,7 +270,9 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
     def run(  # noqa: PLR0913
         self,
         messages: List[ChatMessage],
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        streaming_callback: Optional[
+            Union[StreamingCallbackT, AsyncStreamingCallbackT]
+        ] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         tools: Optional[List[Tool]] = None,
         tools_strict: Optional[bool] = None,
@@ -226,12 +280,15 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         """
         Invokes chat completion based on the provided messages and generation parameters.
 
-        :param messages: A list of ChatMessage instances representing the input messages.
-        :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Additional keyword arguments for text generation. These parameters will
-                                  override the parameters passed during component initialization.
-                                  For details on OpenAI API parameters, see
-                                  [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create).
+        :param messages:
+            A list of ChatMessage instances representing the input messages.
+        :param streaming_callback:
+            A callback function that is called when a new token is received from the stream.
+            Cannot be a coroutine.
+        :param generation_kwargs:
+            Additional keyword arguments for text generation. These parameters will
+            override the parameters passed during component initialization.
+            For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create).
         :param tools:
             A list of tools for which the model can prepare calls. If set, it will override the `tools` parameter set
             during component initialization.
@@ -243,55 +300,32 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         :returns:
             A list containing the generated responses as ChatMessage instances.
         """
+        # validate and select the streaming callback
+        streaming_callback = select_streaming_callback(
+            self.streaming_callback, streaming_callback, requires_async=False
+        )  # type: ignore
 
-        # update generation kwargs by merging with the generation kwargs passed to the run method
-        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+        if len(messages) == 0:
+            return {"replies": []}
 
-        # check if streaming_callback is passed
-        streaming_callback = streaming_callback or self.streaming_callback
-
-        # adapt ChatMessage(s) to the format expected by the OpenAI API
-        openai_formatted_messages = [_convert_message_to_openai_format(message) for message in messages]
-
-        tools = tools or self.tools
-        if tools:
-            tool_names = [tool.name for tool in tools]
-            duplicate_tool_names = {name for name in tool_names if tool_names.count(name) > 1}
-            if duplicate_tool_names:
-                raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
-
-        tools_strict = tools_strict if tools_strict is not None else self.tools_strict
-
-        openai_tools = None
-        if tools:
-            openai_tools = [{"type": "function", "function": {**t.tool_spec, "strict": tools_strict}} for t in tools]
-
-        chat_completion: Union[Stream[ChatCompletionChunk], ChatCompletion] = self.client.chat.completions.create(
-            model=self.model,
-            messages=openai_formatted_messages,  # type: ignore[arg-type] # openai expects list of specific message types
-            stream=streaming_callback is not None,
-            tools=openai_tools,  # type: ignore[arg-type]
-            **generation_kwargs,
+        api_args = self._prepare_api_call(
+            messages, streaming_callback, generation_kwargs, tools, tools_strict
+        )
+        chat_completion: Union[Stream[ChatCompletionChunk], ChatCompletion] = (
+            self.client.chat.completions.create(**api_args)
         )
 
-        completions: List[ChatMessage] = []
-        # if streaming is enabled, the completion is a Stream of ChatCompletionChunk
-        if isinstance(chat_completion, Stream):
-            num_responses = generation_kwargs.pop("n", 1)
-            if num_responses > 1:
-                raise ValueError("Cannot stream multiple responses, please set n=1.")
-            chunks: List[StreamingChunk] = []
-            chunk = None
+        is_streaming = isinstance(chat_completion, Stream)
+        assert is_streaming or streaming_callback is None
 
-            # pylint: disable=not-an-iterable
-            for chunk in chat_completion:
-                if chunk.choices and streaming_callback:
-                    chunk_delta: StreamingChunk = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
-                    chunks.append(chunk_delta)
-                    streaming_callback(chunk_delta)  # invoke callback with the chunk_delta
-            completions = [self._convert_streaming_chunks_to_chat_message(chunk, chunks)]
-        # if streaming is disabled, the completion is a ChatCompletion
-        elif isinstance(chat_completion, ChatCompletion):
+        if is_streaming:
+            completions = self._handle_stream_response(
+                chat_completion, streaming_callback  # type: ignore
+            )
+        else:
+            assert isinstance(
+                chat_completion, ChatCompletion
+            ), "Unexpected response type for non-streaming request."
             completions = [
                 self._convert_chat_completion_to_chat_message(chat_completion, choice)
                 for choice in chat_completion.choices
@@ -299,11 +333,198 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
 
         # before returning, do post-processing of the completions
         for message in completions:
-            self._check_finish_reason(message)
+            self._check_finish_reason(message.meta)
 
         return {"replies": completions}
 
-    def _convert_streaming_chunks_to_chat_message(self, chunk: Any, chunks: List[StreamingChunk]) -> ChatMessage:
+    @component.output_types(replies=List[ChatMessage])
+    async def async_run(  # noqa: PLR0913
+        self,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[
+            Union[StreamingCallbackT, AsyncStreamingCallbackT]
+        ] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        tools: Optional[List[Tool]] = None,
+        tools_strict: Optional[bool] = None,
+    ):
+        """
+        Invokes chat completion based on the provided messages and generation parameters.
+
+        :param messages:
+            A list of ChatMessage instances representing the input messages.
+        :param streaming_callback:
+            A callback function that is called when a new token is received from the stream.
+            Must be a coroutine.
+        :param generation_kwargs:
+            Additional keyword arguments for text generation. These parameters will
+            override the parameters passed during component initialization.
+            For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create).
+        :param tools:
+            A list of tools for which the model can prepare calls. If set, it will override the `tools` parameter set
+            during component initialization.
+        :param tools_strict:
+            Whether to enable strict schema adherence for tool calls. If set to `True`, the model will follow exactly
+            the schema provided in the `parameters` field of the tool definition, but this may increase latency.
+            If set, it will override the `tools_strict` parameter set during component initialization.
+
+        :returns:
+            A list containing the generated responses as ChatMessage instances.
+        """
+        # validate and select the streaming callback
+        streaming_callback = select_streaming_callback(
+            self.streaming_callback, streaming_callback, requires_async=True
+        )  # type: ignore
+
+        if len(messages) == 0:
+            return {"replies": []}
+
+        api_args = self._prepare_api_call(
+            messages, streaming_callback, generation_kwargs, tools, tools_strict
+        )
+        chat_completion: Union[AsyncStream[ChatCompletionChunk], ChatCompletion] = (
+            await self.async_client.chat.completions.create(**api_args)
+        )
+
+        is_streaming = isinstance(chat_completion, AsyncStream)
+        assert is_streaming or streaming_callback is None
+
+        if is_streaming:
+            completions = await self._handle_async_stream_response(
+                chat_completion, streaming_callback  # type: ignore
+            )
+        else:
+            assert isinstance(
+                chat_completion, ChatCompletion
+            ), "Unexpected response type for non-streaming request."
+            completions = [
+                self._convert_chat_completion_to_chat_message(chat_completion, choice)
+                for choice in chat_completion.choices
+            ]
+
+        # before returning, do post-processing of the completions
+        for message in completions:
+            self._check_finish_reason(message.meta)
+
+        return {"replies": completions}
+
+    def _validate_tools(self, tools: Optional[List[Tool]]):
+        if tools is None:
+            return
+
+        tool_names = [tool.name for tool in tools]
+        duplicate_tool_names = {
+            name for name in tool_names if tool_names.count(name) > 1
+        }
+        if duplicate_tool_names:
+            raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
+
+    def _prepare_api_call(  # noqa: PLR0913
+        self,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[
+            Union[StreamingCallbackT, AsyncStreamingCallbackT]
+        ],
+        generation_kwargs: Optional[Dict[str, Any]],
+        tools: Optional[List[Tool]],
+        tools_strict: Optional[bool],
+    ) -> Dict[str, Any]:
+        # update generation kwargs by merging with the generation kwargs passed to the run method
+        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+
+        # adapt ChatMessage(s) to the format expected by the OpenAI API
+        openai_formatted_messages = [
+            _convert_message_to_openai_format(message) for message in messages
+        ]
+
+        tools = tools or self.tools
+        tools_strict = tools_strict if tools_strict is not None else self.tools_strict
+        self._validate_tools(tools)
+
+        openai_tools = None
+        if tools:
+            openai_tools = [
+                {
+                    "type": "function",
+                    "function": {**t.tool_spec, "strict": tools_strict},
+                }
+                for t in tools
+            ]
+
+        is_streaming = streaming_callback is not None
+        num_responses = generation_kwargs.pop("n", 1)
+        if is_streaming and num_responses > 1:
+            raise ValueError("Cannot stream multiple responses, please set n=1.")
+
+        return {
+            "model": self.model,
+            "messages": openai_formatted_messages,  # type: ignore[arg-type] # openai expects list of specific message types
+            "stream": streaming_callback is not None,
+            "tools": openai_tools,  # type: ignore[arg-type]
+            "n": num_responses,
+            **generation_kwargs,
+        }
+
+    def _handle_stream_response(
+        self,
+        chat_completion: Stream,
+        callback: StreamingCallbackT,
+    ) -> List[ChatMessage]:
+        chunks: List[StreamingChunk] = []
+        chunk = None
+
+        for chunk in chat_completion:  # pylint: disable=not-an-iterable
+            assert (
+                len(chunk.choices) == 1
+            ), "Streaming responses should have only one choice."
+            chunk_delta: StreamingChunk = (
+                self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
+            )
+            chunks.append(chunk_delta)
+
+            callback(chunk_delta)
+
+        return [self._convert_streaming_chunks_to_chat_message(chunk, chunks)]
+
+    async def _handle_async_stream_response(
+        self,
+        chat_completion: AsyncStream,
+        callback: AsyncStreamingCallbackT,
+    ) -> List[ChatMessage]:
+        chunks: List[StreamingChunk] = []
+        chunk = None
+
+        async for chunk in chat_completion:  # pylint: disable=not-an-iterable
+            assert (
+                len(chunk.choices) == 1
+            ), "Streaming responses should have only one choice."
+            chunk_delta: StreamingChunk = (
+                self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
+            )
+            chunks.append(chunk_delta)
+
+            await callback(chunk_delta)
+
+        return [self._convert_streaming_chunks_to_chat_message(chunk, chunks)]
+
+    def _check_finish_reason(self, meta: Dict[str, Any]) -> None:
+        if meta["finish_reason"] == "length":
+            logger.warning(
+                "The completion for index {index} has been truncated before reaching a natural stopping point. "
+                "Increase the max_tokens parameter to allow for longer completions.",
+                index=meta["index"],
+                finish_reason=meta["finish_reason"],
+            )
+        if meta["finish_reason"] == "content_filter":
+            logger.warning(
+                "The completion for index {index} has been truncated due to the content filter.",
+                index=meta["index"],
+                finish_reason=meta["finish_reason"],
+            )
+
+    def _convert_streaming_chunks_to_chat_message(
+        self, chunk: Any, chunks: List[StreamingChunk]
+    ) -> ChatMessage:
         """
         Connects the streaming chunks into a single ChatMessage.
 
@@ -333,7 +554,13 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
                 arguments_str = payload["arguments"]
                 try:
                     arguments = json.loads(arguments_str)
-                    tool_calls.append(ToolCall(id=payload["id"], tool_name=payload["name"], arguments=arguments))
+                    tool_calls.append(
+                        ToolCall(
+                            id=payload["id"],
+                            tool_name=payload["name"],
+                            arguments=arguments,
+                        )
+                    )
                 except json.JSONDecodeError:
                     logger.warning(
                         "OpenAI returned a malformed JSON string for tool call arguments. This tool call "
@@ -353,7 +580,9 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
 
         return ChatMessage.from_assistant(text=text, tool_calls=tool_calls, meta=meta)
 
-    def _convert_chat_completion_to_chat_message(self, completion: ChatCompletion, choice: Choice) -> ChatMessage:
+    def _convert_chat_completion_to_chat_message(
+        self, completion: ChatCompletion, choice: Choice
+    ) -> ChatMessage:
         """
         Converts the non-streaming response from the OpenAI API to a ChatMessage.
 
@@ -369,7 +598,13 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
                 arguments_str = openai_tc.function.arguments
                 try:
                     arguments = json.loads(arguments_str)
-                    tool_calls.append(ToolCall(id=openai_tc.id, tool_name=openai_tc.function.name, arguments=arguments))
+                    tool_calls.append(
+                        ToolCall(
+                            id=openai_tc.id,
+                            tool_name=openai_tc.function.name,
+                            arguments=arguments,
+                        )
+                    )
                 except json.JSONDecodeError:
                     logger.warning(
                         "OpenAI returned a malformed JSON string for tool call arguments. This tool call "
@@ -391,7 +626,9 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         )
         return chat_message
 
-    def _convert_chat_completion_chunk_to_streaming_chunk(self, chunk: ChatCompletionChunk) -> StreamingChunk:
+    def _convert_chat_completion_chunk_to_streaming_chunk(
+        self, chunk: ChatCompletionChunk
+    ) -> StreamingChunk:
         """
         Converts the streaming response chunk from the OpenAI API to a StreamingChunk.
 

--- a/haystack_experimental/dataclasses/__init__.py
+++ b/haystack_experimental/dataclasses/__init__.py
@@ -10,6 +10,20 @@ from haystack_experimental.dataclasses.chat_message import (
     ToolCall,
     ToolCallResult,
 )
+from haystack_experimental.dataclasses.streaming_chunk import (
+    AsyncStreamingCallbackT,
+    StreamingCallbackT,
+)
 from haystack_experimental.dataclasses.tool import Tool
 
-__all__ = ["ChatMessage", "ChatRole", "ToolCall", "ToolCallResult", "TextContent", "ChatMessageContentT", "Tool"]
+__all__ = [
+    "AsyncStreamingCallbackT",
+    "ChatMessage",
+    "ChatRole",
+    "StreamingCallbackT",
+    "ToolCall",
+    "ToolCallResult",
+    "TextContent",
+    "ChatMessageContentT",
+    "Tool",
+]

--- a/haystack_experimental/dataclasses/streaming_chunk.py
+++ b/haystack_experimental/dataclasses/streaming_chunk.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Awaitable, Callable, Optional, Union
+
+from haystack.dataclasses import StreamingChunk
+
+from haystack_experimental.util import is_callable_async_compatible
+
+StreamingCallbackT = Callable[[StreamingChunk], None]
+AsyncStreamingCallbackT = Callable[[StreamingChunk], Awaitable[None]]
+
+
+def select_streaming_callback(
+    init_callback: Optional[Union[StreamingCallbackT, AsyncStreamingCallbackT]],
+    runtime_callback: Optional[Union[StreamingCallbackT, AsyncStreamingCallbackT]],
+    requires_async: bool,
+) -> Optional[Union[StreamingCallbackT, AsyncStreamingCallbackT]]:
+    """
+    Picks the correct streaming callback given an optional initial and runtime callback.
+
+    The runtime callback takes precedence over the initial callback.
+
+    :param init_callback:
+        The initial callback.
+    :param runtime_callback:
+        The runtime callback.
+    :param requires_async:
+        Whether the selected callback must be async compatible.
+    :returns:
+        The selected callback.
+    """
+    if init_callback is not None:
+        if requires_async and not is_callable_async_compatible(init_callback):
+            raise ValueError("The init callback must be async compatible.")
+        if not requires_async and is_callable_async_compatible(init_callback):
+            raise ValueError("The init callback cannot be a coroutine.")
+
+    if runtime_callback is not None:
+        if requires_async and not is_callable_async_compatible(runtime_callback):
+            raise ValueError("The runtime callback must be async compatible.")
+        if not requires_async and is_callable_async_compatible(runtime_callback):
+            raise ValueError("The runtime callback cannot be a coroutine.")
+
+    return runtime_callback or init_callback

--- a/haystack_experimental/util/__init__.py
+++ b/haystack_experimental/util/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from haystack_experimental.util.asynchronous import is_callable_async_compatible
 from haystack_experimental.util.auth import serialize_secrets_inplace
 
-__all__ = ["serialize_secrets_inplace"]
+__all__ = ["is_callable_async_compatible", "serialize_secrets_inplace"]

--- a/haystack_experimental/util/asynchronous.py
+++ b/haystack_experimental/util/asynchronous.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+from typing import Callable
+
+
+def is_callable_async_compatible(func: Callable) -> bool:
+    """
+    Returns if the given callable is usable inside a component's `async_run` method.
+
+    :param callable:
+        The callable to check.
+    :returns:
+        True if the callable is compatible, False otherwise.
+    """
+    return inspect.iscoroutinefunction(func)

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -11,7 +11,12 @@ import json
 from datetime import datetime
 
 from openai import OpenAIError
-from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage, ChatCompletionMessageToolCall
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+)
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message_tool_call import Function
 from openai.types.chat import chat_completion_chunk
@@ -20,9 +25,17 @@ from openai import Stream
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import StreamingChunk
 from haystack.utils.auth import Secret
-from haystack_experimental.dataclasses import ChatMessage, Tool, ToolCall, ChatRole, TextContent
-from haystack_experimental.components.generators.chat.openai import OpenAIChatGenerator, _convert_message_to_openai_format, OpenAIChatGeneratorBase
-
+from haystack_experimental.dataclasses import (
+    ChatMessage,
+    Tool,
+    ToolCall,
+    ChatRole,
+    TextContent,
+)
+from haystack_experimental.components.generators.chat.openai import (
+    OpenAIChatGenerator,
+    _convert_message_to_openai_format,
+)
 
 
 @pytest.fixture
@@ -31,6 +44,7 @@ def chat_messages():
         ChatMessage.from_system("You are a helpful assistant"),
         ChatMessage.from_user("What's the capital of France"),
     ]
+
 
 class MockStream(Stream[ChatCompletionChunk]):
     def __init__(self, mock_chunk: ChatCompletionChunk, client=None, *args, **kwargs):
@@ -42,34 +56,47 @@ class MockStream(Stream[ChatCompletionChunk]):
         # Yielding only one ChatCompletionChunk object
         yield self.mock_chunk
 
+
 @pytest.fixture
 def mock_chat_completion_chunk():
     """
     Mock the OpenAI API completion chunk response and reuse it for tests
     """
 
-    with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
+    with patch(
+        "openai.resources.chat.completions.Completions.create"
+    ) as mock_chat_completion_create:
         completion = ChatCompletionChunk(
             id="foo",
             model="gpt-4",
             object="chat.completion.chunk",
             choices=[
                 chat_completion_chunk.Choice(
-                    finish_reason="stop", logprobs=None, index=0, delta=chat_completion_chunk.ChoiceDelta(content="Hello", role="assistant")
+                    finish_reason="stop",
+                    logprobs=None,
+                    index=0,
+                    delta=chat_completion_chunk.ChoiceDelta(
+                        content="Hello", role="assistant"
+                    ),
                 )
             ],
             created=int(datetime.now().timestamp()),
             usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
         )
-        mock_chat_completion_create.return_value = MockStream(completion, cast_to=None, response=None, client=None)
+        mock_chat_completion_create.return_value = MockStream(
+            completion, cast_to=None, response=None, client=None
+        )
         yield mock_chat_completion_create
+
 
 @pytest.fixture
 def mock_chat_completion():
     """
     Mock the OpenAI API completion response and reuse it for tests
     """
-    with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
+    with patch(
+        "openai.resources.chat.completions.Completions.create"
+    ) as mock_chat_completion_create:
         completion = ChatCompletion(
             id="foo",
             model="gpt-4",
@@ -79,7 +106,9 @@ def mock_chat_completion():
                     finish_reason="stop",
                     logprobs=None,
                     index=0,
-                    message=ChatCompletionMessage(content="Hello world!", role="assistant"),
+                    message=ChatCompletionMessage(
+                        content="Hello world!", role="assistant"
+                    ),
                 )
             ],
             created=int(datetime.now().timestamp()),
@@ -89,47 +118,64 @@ def mock_chat_completion():
         mock_chat_completion_create.return_value = completion
         yield mock_chat_completion_create
 
+
 @pytest.fixture
 def mock_chat_completion_chunk_with_tools():
     """
     Mock the OpenAI API completion chunk response and reuse it for tests
     """
 
-    with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
+    with patch(
+        "openai.resources.chat.completions.Completions.create"
+    ) as mock_chat_completion_create:
         completion = ChatCompletionChunk(
             id="foo",
             model="gpt-4",
             object="chat.completion.chunk",
             choices=[
                 chat_completion_chunk.Choice(
-                    finish_reason="tool_calls", logprobs=None, index=0, delta=chat_completion_chunk.ChoiceDelta(
+                    finish_reason="tool_calls",
+                    logprobs=None,
+                    index=0,
+                    delta=chat_completion_chunk.ChoiceDelta(
                         role="assistant",
-                        tool_calls=[chat_completion_chunk.ChoiceDeltaToolCall(
-                            index=0,
-                            id="123", type="function", function=chat_completion_chunk.ChoiceDeltaToolCallFunction(name="weather", arguments='{"city": "Paris"}')
-                        )])
+                        tool_calls=[
+                            chat_completion_chunk.ChoiceDeltaToolCall(
+                                index=0,
+                                id="123",
+                                type="function",
+                                function=chat_completion_chunk.ChoiceDeltaToolCallFunction(
+                                    name="weather", arguments='{"city": "Paris"}'
+                                ),
+                            )
+                        ],
+                    ),
                 )
             ],
             created=int(datetime.now().timestamp()),
             usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
         )
-        mock_chat_completion_create.return_value = MockStream(completion, cast_to=None, response=None, client=None)
+        mock_chat_completion_create.return_value = MockStream(
+            completion, cast_to=None, response=None, client=None
+        )
         yield mock_chat_completion_create
+
 
 @pytest.fixture
 def tools():
     tool_parameters = {
-    "type": "object",
-    "properties": {
-        "city": {"type": "string"}
-    },
-    "required": ["city"]
-}
-    tool = Tool(name="weather", description="useful to determine the weather in a given location",
-                    parameters=tool_parameters, function=lambda x:x)
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+    tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters=tool_parameters,
+        function=lambda x: x,
+    )
 
     return [tool]
-
 
 
 class TestOpenAIChatGenerator:
@@ -137,7 +183,7 @@ class TestOpenAIChatGenerator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = OpenAIChatGenerator()
         assert component.client.api_key == "test-api-key"
-        assert component.model == "gpt-3.5-turbo"
+        assert component.model == "gpt-4o-mini"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.client.timeout == 30
@@ -158,7 +204,12 @@ class TestOpenAIChatGenerator:
             OpenAIChatGenerator(tools=duplicate_tools)
 
     def test_init_with_parameters(self, monkeypatch):
-        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=lambda x: x)
+        tool = Tool(
+            name="name",
+            description="description",
+            parameters={"x": {"type": "string"}},
+            function=lambda x: x,
+        )
 
         monkeypatch.setenv("OPENAI_TIMEOUT", "100")
         monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
@@ -176,7 +227,10 @@ class TestOpenAIChatGenerator:
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-4"
         assert component.streaming_callback is print_streaming_chunk
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.generation_kwargs == {
+            "max_tokens": 10,
+            "some_test_param": "test-params",
+        }
         assert component.client.timeout == 40.0
         assert component.client.max_retries == 1
         assert component.tools == [tool]
@@ -195,7 +249,10 @@ class TestOpenAIChatGenerator:
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-4"
         assert component.streaming_callback is print_streaming_chunk
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.generation_kwargs == {
+            "max_tokens": 10,
+            "some_test_param": "test-params",
+        }
         assert component.client.timeout == 100.0
         assert component.client.max_retries == 10
 
@@ -206,19 +263,30 @@ class TestOpenAIChatGenerator:
         assert data == {
             "type": "haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gpt-3.5-turbo",
+                "api_key": {
+                    "env_vars": ["OPENAI_API_KEY"],
+                    "strict": True,
+                    "type": "env_var",
+                },
+                "model": "gpt-4o-mini",
                 "organization": None,
                 "streaming_callback": None,
                 "api_base_url": None,
                 "generation_kwargs": {},
                 "tools": None,
                 "tools_strict": False,
+                "max_retries": None,
+                "timeout": None,
             },
         }
 
     def test_to_dict_with_parameters(self, monkeypatch):
-        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
+        tool = Tool(
+            name="name",
+            description="description",
+            parameters={"x": {"type": "string"}},
+            function=print,
+        )
 
         monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = OpenAIChatGenerator(
@@ -227,8 +295,10 @@ class TestOpenAIChatGenerator:
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-            tools = [tool],
+            tools=[tool],
             tools_strict=True,
+            max_retries=10,
+            timeout=100.0,
         )
         data = component.to_dict()
 
@@ -239,21 +309,26 @@ class TestOpenAIChatGenerator:
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
+                "max_retries": 10,
+                "timeout": 100.0,
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                'tools': [
-               {
-                   'description': 'description',
-                   'function': 'builtins.print',
-                   'name': 'name',
-                   'parameters': {
-                       'x': {
-                           'type': 'string',
-                       },
-                   },
-               },
-           ],
-              'tools_strict': True,
+                "generation_kwargs": {
+                    "max_tokens": 10,
+                    "some_test_param": "test-params",
+                },
+                "tools": [
+                    {
+                        "description": "description",
+                        "function": "builtins.print",
+                        "name": "name",
+                        "parameters": {
+                            "x": {
+                                "type": "string",
+                            },
+                        },
+                    },
+                ],
+                "tools_strict": True,
             },
         }
 
@@ -269,15 +344,23 @@ class TestOpenAIChatGenerator:
         assert data == {
             "type": "haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {
+                    "env_vars": ["OPENAI_API_KEY"],
+                    "strict": True,
+                    "type": "env_var",
+                },
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
+                "max_retries": None,
+                "timeout": None,
                 "streaming_callback": "test_openai.<lambda>",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "generation_kwargs": {
+                    "max_tokens": 10,
+                    "some_test_param": "test-params",
+                },
                 "tools": None,
                 "tools_strict": False,
-
             },
         }
 
@@ -286,24 +369,33 @@ class TestOpenAIChatGenerator:
         data = {
             "type": "haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {
+                    "env_vars": ["OPENAI_API_KEY"],
+                    "strict": True,
+                    "type": "env_var",
+                },
                 "model": "gpt-4",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                'tools': [
-               {
-                   'description': 'description',
-                   'function': 'builtins.print',
-                   'name': 'name',
-                   'parameters': {
-                       'x': {
-                           'type': 'string',
-                       },
-                   },
-               },
-           ],
-              'tools_strict': True,
+                "max_retries": 10,
+                "timeout": 100.0,
+                "generation_kwargs": {
+                    "max_tokens": 10,
+                    "some_test_param": "test-params",
+                },
+                "tools": [
+                    {
+                        "description": "description",
+                        "function": "builtins.print",
+                        "name": "name",
+                        "parameters": {
+                            "x": {
+                                "type": "string",
+                            },
+                        },
+                    },
+                ],
+                "tools_strict": True,
             },
         }
         component = OpenAIChatGenerator.from_dict(data)
@@ -312,22 +404,41 @@ class TestOpenAIChatGenerator:
         assert component.model == "gpt-4"
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.generation_kwargs == {
+            "max_tokens": 10,
+            "some_test_param": "test-params",
+        }
         assert component.api_key == Secret.from_env_var("OPENAI_API_KEY")
-        assert component.tools == [Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)]
+        assert component.tools == [
+            Tool(
+                name="name",
+                description="description",
+                parameters={"x": {"type": "string"}},
+                function=print,
+            )
+        ]
         assert component.tools_strict
+        assert component.client.timeout == 100.0
+        assert component.client.max_retries == 10
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         data = {
             "type": "haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {
+                    "env_vars": ["OPENAI_API_KEY"],
+                    "strict": True,
+                    "type": "env_var",
+                },
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "generation_kwargs": {
+                    "max_tokens": 10,
+                    "some_test_param": "test-params",
+                },
             },
         }
         with pytest.raises(ValueError):
@@ -346,7 +457,8 @@ class TestOpenAIChatGenerator:
 
     def test_run_with_params(self, chat_messages, mock_chat_completion):
         component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_tokens": 10, "temperature": 0.5},
         )
         response = component.run(chat_messages)
 
@@ -370,7 +482,8 @@ class TestOpenAIChatGenerator:
             streaming_callback_called = True
 
         component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
+            api_key=Secret.from_token("test-api-key"),
+            streaming_callback=streaming_callback,
         )
         response = component.run(chat_messages)
 
@@ -385,7 +498,9 @@ class TestOpenAIChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
         assert "Hello" in response["replies"][0].text  # see mock_chat_completion_chunk
 
-    def test_run_with_streaming_callback_in_run_method(self, chat_messages, mock_chat_completion_chunk):
+    def test_run_with_streaming_callback_in_run_method(
+        self, chat_messages, mock_chat_completion_chunk
+    ):
         streaming_callback_called = False
 
         def streaming_callback(chunk: StreamingChunk) -> None:
@@ -411,13 +526,17 @@ class TestOpenAIChatGenerator:
         component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
         messages = [
             ChatMessage.from_assistant(
-                "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
+                "",
+                meta={
+                    "finish_reason": "content_filter" if i % 2 == 0 else "length",
+                    "index": i,
+                },
             )
             for i, _ in enumerate(range(4))
         ]
 
         for m in messages:
-            component._check_finish_reason(m)
+            component._check_finish_reason(m.meta)
 
         # check truncation warning
         message_template = (
@@ -445,7 +564,23 @@ class TestOpenAIChatGenerator:
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
-        assert "gpt-3.5" in message.meta["model"]
+        assert "gpt-4o" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_async(self):
+        chat_messages = [ChatMessage.from_user("What's the capital of France")]
+        component = OpenAIChatGenerator(generation_kwargs={"n": 1})
+        results = await component.async_run(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "gpt-4o" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -457,6 +592,17 @@ class TestOpenAIChatGenerator:
         component = OpenAIChatGenerator(model="something-obviously-wrong")
         with pytest.raises(OpenAIError):
             component.run(chat_messages)
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_wrong_model_async(self, chat_messages):
+        component = OpenAIChatGenerator(model="something-obviously-wrong")
+        with pytest.raises(OpenAIError):
+            await component.async_run(chat_messages)
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -475,48 +621,149 @@ class TestOpenAIChatGenerator:
 
         callback = Callback()
         component = OpenAIChatGenerator(streaming_callback=callback)
-        results = component.run([ChatMessage.from_user("What's the capital of France?")])
+        results = component.run(
+            [ChatMessage.from_user("What's the capital of France?")]
+        )
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
 
-        assert "gpt-3.5" in message.meta["model"]
+        assert "gpt-4o" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert callback.counter > 1
         assert "Paris" in callback.responses
 
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_streaming_async(self):
+        counter = 0
+        responses = ""
 
+        async def callback(chunk: StreamingChunk):
+            nonlocal counter
+            nonlocal responses
+            counter += 1
+            responses += chunk.content if chunk.content else ""
 
+        component = OpenAIChatGenerator(streaming_callback=callback)
+        results = await component.async_run(
+            [ChatMessage.from_user("What's the capital of France?")]
+        )
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+
+        assert "gpt-4o" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        assert counter > 1
+        assert "Paris" in responses
+
+    @pytest.mark.asyncio
+    async def test_streaming_callback_compatibility(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+        async def async_callback(chunk: StreamingChunk):
+            pass
+
+        def sync_callback(chunk: StreamingChunk):
+            pass
+
+        with pytest.raises(ValueError, match="init callback must be async compatible"):
+            gen = OpenAIChatGenerator(streaming_callback=sync_callback)
+            await gen.async_run([])
+
+        with pytest.raises(
+            ValueError, match="runtime callback must be async compatible"
+        ):
+            gen = OpenAIChatGenerator(streaming_callback=async_callback)
+            await gen.async_run([], streaming_callback=sync_callback)
+
+        await gen.async_run([])
+
+        with pytest.raises(ValueError, match="init callback cannot be a coroutine"):
+            gen = OpenAIChatGenerator(streaming_callback=async_callback)
+            gen.run([])
+
+        with pytest.raises(ValueError, match="runtime callback cannot be a coroutine"):
+            gen = OpenAIChatGenerator(streaming_callback=sync_callback)
+            gen.run([], streaming_callback=async_callback)
+
+        gen.run([])
 
     def test_convert_message_to_openai_format(self):
         message = ChatMessage.from_system("You are good assistant")
-        assert _convert_message_to_openai_format(message) == {"role": "system", "content": "You are good assistant"}
+        assert _convert_message_to_openai_format(message) == {
+            "role": "system",
+            "content": "You are good assistant",
+        }
 
         message = ChatMessage.from_user("I have a question")
-        assert _convert_message_to_openai_format(message) == {"role": "user", "content": "I have a question"}
+        assert _convert_message_to_openai_format(message) == {
+            "role": "user",
+            "content": "I have a question",
+        }
 
-        message = ChatMessage.from_assistant(text="I have an answer", meta={"finish_reason": "stop"})
-        assert _convert_message_to_openai_format(message) == {"role": "assistant", "content": "I have an answer"}
+        message = ChatMessage.from_assistant(
+            text="I have an answer", meta={"finish_reason": "stop"}
+        )
+        assert _convert_message_to_openai_format(message) == {
+            "role": "assistant",
+            "content": "I have an answer",
+        }
 
-        message = ChatMessage.from_assistant(tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})])
-        assert _convert_message_to_openai_format(message) == {"role": "assistant", "tool_calls": [{"id": "123", "type": "function", "function": {"name": "weather", "arguments": '{"city": "Paris"}'}}]}
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
+            ]
+        )
+        assert _convert_message_to_openai_format(message) == {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "123",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": '{"city": "Paris"}'},
+                }
+            ],
+        }
 
-        tool_result=json.dumps({"weather": "sunny", "temperature": "25"})
-        message = ChatMessage.from_tool(tool_result=tool_result, origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}))
-        assert _convert_message_to_openai_format(message) == {"role": "tool", "content": tool_result, "tool_call_id": "123"}
+        tool_result = json.dumps({"weather": "sunny", "temperature": "25"})
+        message = ChatMessage.from_tool(
+            tool_result=tool_result,
+            origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}),
+        )
+        assert _convert_message_to_openai_format(message) == {
+            "role": "tool",
+            "content": tool_result,
+            "tool_call_id": "123",
+        }
 
     def test_convert_message_to_openai_invalid(self):
         message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
         with pytest.raises(ValueError):
             _convert_message_to_openai_format(message)
 
-        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[TextContent(text="I have an answer"), TextContent(text="I have another answer")])
+        message = ChatMessage(
+            _role=ChatRole.ASSISTANT,
+            _content=[
+                TextContent(text="I have an answer"),
+                TextContent(text="I have another answer"),
+            ],
+        )
         with pytest.raises(ValueError):
             _convert_message_to_openai_format(message)
 
-        tool_call_null_id = ToolCall(id=None, tool_name="weather", arguments={"city": "Paris"})
+        tool_call_null_id = ToolCall(
+            id=None, tool_name="weather", arguments={"city": "Paris"}
+        )
         message = ChatMessage.from_assistant(tool_calls=[tool_call_null_id])
         with pytest.raises(ValueError):
             _convert_message_to_openai_format(message)
@@ -525,10 +772,11 @@ class TestOpenAIChatGenerator:
         with pytest.raises(ValueError):
             _convert_message_to_openai_format(message)
 
-
     def test_run_with_tools(self, tools):
 
-        with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
+        with patch(
+            "openai.resources.chat.completions.Completions.create"
+        ) as mock_chat_completion_create:
             completion = ChatCompletion(
                 id="foo",
                 model="gpt-4",
@@ -538,20 +786,36 @@ class TestOpenAIChatGenerator:
                         finish_reason="tool_calls",
                         logprobs=None,
                         index=0,
-                        message=ChatCompletionMessage(role="assistant",
-                                                    tool_calls=[ChatCompletionMessageToolCall(
-                                                        id="123", type="function", function=Function(name="weather", arguments='{"city": "Paris"}'))])
+                        message=ChatCompletionMessage(
+                            role="assistant",
+                            tool_calls=[
+                                ChatCompletionMessageToolCall(
+                                    id="123",
+                                    type="function",
+                                    function=Function(
+                                        name="weather", arguments='{"city": "Paris"}'
+                                    ),
+                                )
+                            ],
+                        ),
                     )
                 ],
                 created=int(datetime.now().timestamp()),
-                usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+                usage={
+                    "prompt_tokens": 57,
+                    "completion_tokens": 40,
+                    "total_tokens": 97,
+                },
             )
 
             mock_chat_completion_create.return_value = completion
 
-            component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"), tools=tools)
-            response = component.run([ChatMessage.from_user("What's the weather like in Paris?")])
-
+            component = OpenAIChatGenerator(
+                api_key=Secret.from_token("test-api-key"), tools=tools
+            )
+            response = component.run(
+                [ChatMessage.from_user("What's the weather like in Paris?")]
+            )
 
         assert len(response["replies"]) == 1
         message = response["replies"][0]
@@ -563,7 +827,9 @@ class TestOpenAIChatGenerator:
         assert tool_call.arguments == {"city": "Paris"}
         assert message.meta["finish_reason"] == "tool_calls"
 
-    def test_run_with_tools_streaming(self, mock_chat_completion_chunk_with_tools, tools):
+    def test_run_with_tools_streaming(
+        self, mock_chat_completion_chunk_with_tools, tools
+    ):
 
         streaming_callback_called = False
 
@@ -572,7 +838,8 @@ class TestOpenAIChatGenerator:
             streaming_callback_called = True
 
         component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
+            api_key=Secret.from_token("test-api-key"),
+            streaming_callback=streaming_callback,
         )
         chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         response = component.run(chat_messages, tools=tools)
@@ -599,7 +866,9 @@ class TestOpenAIChatGenerator:
     def test_invalid_tool_call_json(self, tools, caplog):
         caplog.set_level(logging.WARNING)
 
-        with patch("openai.resources.chat.completions.Completions.create") as mock_create:
+        with patch(
+            "openai.resources.chat.completions.Completions.create"
+        ) as mock_create:
             mock_create.return_value = ChatCompletion(
                 id="test",
                 model="gpt-4",
@@ -611,22 +880,39 @@ class TestOpenAIChatGenerator:
                         message=ChatCompletionMessage(
                             role="assistant",
                             tool_calls=[
-                                ChatCompletionMessageToolCall(id="1", type="function", function=Function(name="weather", arguments='"invalid": "json"')),
-                            ]
-                        )
+                                ChatCompletionMessageToolCall(
+                                    id="1",
+                                    type="function",
+                                    function=Function(
+                                        name="weather", arguments='"invalid": "json"'
+                                    ),
+                                ),
+                            ],
+                        ),
                     )
                 ],
                 created=1234567890,
-                usage={"prompt_tokens": 50, "completion_tokens": 30, "total_tokens": 80}
+                usage={
+                    "prompt_tokens": 50,
+                    "completion_tokens": 30,
+                    "total_tokens": 80,
+                },
             )
 
-            component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"), tools=tools)
-            response = component.run([ChatMessage.from_user("What's the weather in Paris?")])
+            component = OpenAIChatGenerator(
+                api_key=Secret.from_token("test-api-key"), tools=tools
+            )
+            response = component.run(
+                [ChatMessage.from_user("What's the weather in Paris?")]
+            )
 
         assert len(response["replies"]) == 1
         message = response["replies"][0]
         assert len(message.tool_calls) == 0
-        assert "OpenAI returned a malformed JSON string for tool call arguments" in caplog.text
+        assert (
+            "OpenAI returned a malformed JSON string for tool call arguments"
+            in caplog.text
+        )
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -638,6 +924,27 @@ class TestOpenAIChatGenerator:
         chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         component = OpenAIChatGenerator(tools=tools)
         results = component.run(chat_messages)
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_with_tools_async(self, tools):
+
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = OpenAIChatGenerator(tools=tools)
+        results = await component.async_run(chat_messages)
         assert len(results["replies"]) == 1
         message = results["replies"][0]
 

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -4,9 +4,18 @@ import datetime
 
 from haystack import Pipeline
 
-from haystack_experimental.dataclasses import ChatMessage, ToolCall, ToolCallResult, ChatRole
+from haystack_experimental.dataclasses import (
+    ChatMessage,
+    ToolCall,
+    ToolCallResult,
+    ChatRole,
+)
 from haystack_experimental.dataclasses.tool import Tool, ToolInvocationError
-from haystack_experimental.components.tools.tool_invoker import ToolInvoker, ToolNotFoundException, StringConversionError
+from haystack_experimental.components.tools.tool_invoker import (
+    ToolInvoker,
+    ToolNotFoundException,
+    StringConversionError,
+)
 from haystack_experimental.components.generators.chat import OpenAIChatGenerator
 
 
@@ -16,16 +25,17 @@ def weather_function(location):
         "Paris": {"weather": "mostly cloudy", "temperature": 8, "unit": "celsius"},
         "Rome": {"weather": "sunny", "temperature": 14, "unit": "celsius"},
     }
-    return weather_info.get(location, {"weather": "unknown", "temperature": 0, "unit": "celsius"})
+    return weather_info.get(
+        location, {"weather": "unknown", "temperature": 0, "unit": "celsius"}
+    )
 
 
 weather_parameters = {
     "type": "object",
-    "properties": {
-        "location": {"type": "string"}
-    },
-    "required": ["location"]
+    "properties": {"location": {"type": "string"}},
+    "required": ["location"],
 }
+
 
 @pytest.fixture
 def weather_tool():
@@ -33,8 +43,9 @@ def weather_tool():
         name="weather_tool",
         description="Provides weather information for a given location.",
         parameters=weather_parameters,
-        function=weather_function
+        function=weather_function,
     )
+
 
 @pytest.fixture
 def faulty_tool():
@@ -44,23 +55,30 @@ def faulty_tool():
     faulty_tool_parameters = {
         "type": "object",
         "properties": {"location": {"type": "string"}},
-        "required": ["location"]
+        "required": ["location"],
     }
 
     return Tool(
         name="faulty_tool",
         description="A tool that always fails when invoked.",
         parameters=faulty_tool_parameters,
-        function=faulty_tool_func
+        function=faulty_tool_func,
     )
+
 
 @pytest.fixture
 def invoker(weather_tool):
-    return ToolInvoker(tools=[weather_tool], raise_on_failure=True, convert_result_to_json_string=False)
+    return ToolInvoker(
+        tools=[weather_tool], raise_on_failure=True, convert_result_to_json_string=False
+    )
+
 
 @pytest.fixture
 def faulty_invoker(faulty_tool):
-    return ToolInvoker(tools=[faulty_tool], raise_on_failure=True, convert_result_to_json_string=False)
+    return ToolInvoker(
+        tools=[faulty_tool], raise_on_failure=True, convert_result_to_json_string=False
+    )
+
 
 class TestToolInvoker:
 
@@ -68,7 +86,7 @@ class TestToolInvoker:
         invoker = ToolInvoker(tools=[weather_tool])
 
         assert invoker.tools == [weather_tool]
-        assert invoker._tools_with_names == {'weather_tool': weather_tool}
+        assert invoker._tools_with_names == {"weather_tool": weather_tool}
         assert invoker.raise_on_failure
         assert not invoker.convert_result_to_json_string
 
@@ -87,13 +105,8 @@ class TestToolInvoker:
 
     def test_run(self, invoker):
 
-        tool_call = ToolCall(
-            tool_name="weather_tool",
-            arguments={"location": "Berlin"}
-        )
-        message = ChatMessage.from_assistant(
-            tool_calls=[tool_call]
-        )
+        tool_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
+        message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
         result = invoker.run(messages=[message])
         assert "tool_messages" in result
@@ -107,7 +120,9 @@ class TestToolInvoker:
         tool_call_result = tool_message.tool_call_result
 
         assert isinstance(tool_call_result, ToolCallResult)
-        assert tool_call_result.result == str({"weather": "mostly sunny", "temperature": 7, "unit": "celsius"})
+        assert tool_call_result.result == str(
+            {"weather": "mostly sunny", "temperature": 7, "unit": "celsius"}
+        )
         assert tool_call_result.origin == tool_call
         assert not tool_call_result.error
 
@@ -134,7 +149,7 @@ class TestToolInvoker:
         assert "tool_messages" in result
         assert len(result["tool_messages"]) == 3
 
-        for i,tool_message in enumerate(result["tool_messages"]):
+        for i, tool_message in enumerate(result["tool_messages"]):
             assert isinstance(tool_message, ChatMessage)
             assert tool_message.is_from(ChatRole.TOOL)
 
@@ -145,16 +160,11 @@ class TestToolInvoker:
             assert not tool_call_result.error
             assert tool_call_result.origin == tool_calls[i]
 
-
-
     def test_tool_not_found_error(self, invoker):
         tool_call = ToolCall(
-            tool_name="non_existent_tool",
-            arguments={"location": "Berlin"}
+            tool_name="non_existent_tool", arguments={"location": "Berlin"}
         )
-        tool_call_message = ChatMessage.from_assistant(
-            tool_calls=[tool_call]
-        )
+        tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
         with pytest.raises(ToolNotFoundException):
             invoker.run(messages=[tool_call_message])
@@ -163,12 +173,9 @@ class TestToolInvoker:
         invoker.raise_on_failure = False
 
         tool_call = ToolCall(
-            tool_name="non_existent_tool",
-            arguments={"location": "Berlin"}
+            tool_name="non_existent_tool", arguments={"location": "Berlin"}
         )
-        tool_call_message = ChatMessage.from_assistant(
-            tool_calls=[tool_call]
-        )
+        tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
         result = invoker.run(messages=[tool_call_message])
         tool_message = result["tool_messages"][0]
@@ -177,13 +184,8 @@ class TestToolInvoker:
         assert "not found" in tool_message.tool_call_results[0].result
 
     def test_tool_invocation_error(self, faulty_invoker):
-        tool_call = ToolCall(
-            tool_name="faulty_tool",
-            arguments={"location": "Berlin"}
-        )
-        tool_call_message = ChatMessage.from_assistant(
-            tool_calls=[tool_call]
-        )
+        tool_call = ToolCall(tool_name="faulty_tool", arguments={"location": "Berlin"})
+        tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
         with pytest.raises(ToolInvocationError):
             faulty_invoker.run(messages=[tool_call_message])
@@ -191,13 +193,8 @@ class TestToolInvoker:
     def test_tool_invocation_error_does_not_raise_exception(self, faulty_invoker):
         faulty_invoker.raise_on_failure = False
 
-        tool_call = ToolCall(
-            tool_name="faulty_tool",
-            arguments={"location": "Berlin"}
-        )
-        tool_call_message = ChatMessage.from_assistant(
-            tool_calls=[tool_call]
-        )
+        tool_call = ToolCall(tool_name="faulty_tool", arguments={"location": "Berlin"})
+        tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
         result = faulty_invoker.run(messages=[tool_call_message])
         tool_message = result["tool_messages"][0]
@@ -207,30 +204,27 @@ class TestToolInvoker:
     def test_string_conversion_error(self, invoker):
         invoker.convert_result_to_json_string = True
 
-        tool_call = ToolCall(
-            tool_name="weather_tool",
-            arguments={"location": "Berlin"}
-        )
+        tool_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
 
         tool_result = datetime.datetime.now()
         with pytest.raises(StringConversionError):
-            invoker._prepare_tool_result_message(result=tool_result, tool_call=tool_call)
+            invoker._prepare_tool_result_message(
+                result=tool_result, tool_call=tool_call
+            )
 
     def test_string_conversion_error_does_not_raise_exception(self, invoker):
         invoker.convert_result_to_json_string = True
         invoker.raise_on_failure = False
 
-        tool_call = ToolCall(
-            tool_name="weather_tool",
-            arguments={"location": "Berlin"}
-        )
+        tool_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
 
         tool_result = datetime.datetime.now()
-        tool_message = invoker._prepare_tool_result_message(result=tool_result, tool_call=tool_call)
+        tool_message = invoker._prepare_tool_result_message(
+            result=tool_result, tool_call=tool_call
+        )
 
         assert tool_message.tool_call_results[0].error
         assert "Failed to convert" in tool_message.tool_call_results[0].result
-
 
     def test_to_dict(self, invoker, weather_tool):
         data = invoker.to_dict()
@@ -239,7 +233,7 @@ class TestToolInvoker:
             "init_parameters": {
                 "tools": [weather_tool.to_dict()],
                 "raise_on_failure": True,
-                "convert_result_to_json_string": False
+                "convert_result_to_json_string": False,
             },
         }
 
@@ -249,12 +243,12 @@ class TestToolInvoker:
             "init_parameters": {
                 "tools": [weather_tool.to_dict()],
                 "raise_on_failure": True,
-                "convert_result_to_json_string": False
+                "convert_result_to_json_string": False,
             },
         }
         invoker = ToolInvoker.from_dict(data)
         assert invoker.tools == [weather_tool]
-        assert invoker._tools_with_names == {'weather_tool': weather_tool}
+        assert invoker._tools_with_names == {"weather_tool": weather_tool}
         assert invoker.raise_on_failure
         assert not invoker.convert_result_to_json_string
 
@@ -268,57 +262,57 @@ class TestToolInvoker:
 
         pipeline_dict = pipeline.to_dict()
         assert pipeline_dict == {
-            'metadata': {},
-            'max_loops_allowed': 100,
-            'components': {
-                'invoker': {
-                    'type': 'haystack_experimental.components.tools.tool_invoker.ToolInvoker',
-                    'init_parameters': {
-                        'tools': [
+            "metadata": {},
+            "max_loops_allowed": 100,
+            "components": {
+                "invoker": {
+                    "type": "haystack_experimental.components.tools.tool_invoker.ToolInvoker",
+                    "init_parameters": {
+                        "tools": [
                             {
-                                'name': 'weather_tool',
-                                'description': 'Provides weather information for a given location.',
-                                'parameters': {
-                                    'type': 'object',
-                                    'properties': {
-                                        'location': {'type': 'string'}
-                                    },
-                                    'required': ['location']
+                                "name": "weather_tool",
+                                "description": "Provides weather information for a given location.",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"location": {"type": "string"}},
+                                    "required": ["location"],
                                 },
-                                'function': 'test.components.tools.test_tool_invoker.weather_function'
+                                "function": "test.components.tools.test_tool_invoker.weather_function",
                             }
                         ],
-                        'raise_on_failure': True,
-                        'convert_result_to_json_string': False
-                    }
+                        "raise_on_failure": True,
+                        "convert_result_to_json_string": False,
+                    },
                 },
-                'chatgenerator': {
-                    'type': 'haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator',
-                    'init_parameters': {
-                        'model': 'gpt-3.5-turbo',
-                        'streaming_callback': None,
-                        'api_base_url': None,
-                        'organization': None,
-                        'generation_kwargs': {},
-                        'api_key': {
-                            'type': 'env_var',
-                            'env_vars': ['OPENAI_API_KEY'],
-                            'strict': True
+                "chatgenerator": {
+                    "type": "haystack_experimental.components.generators.chat.openai.OpenAIChatGenerator",
+                    "init_parameters": {
+                        "model": "gpt-4o-mini",
+                        "streaming_callback": None,
+                        "api_base_url": None,
+                        "organization": None,
+                        "generation_kwargs": {},
+                        "max_retries": None,
+                        "timeout": None,
+                        "api_key": {
+                            "type": "env_var",
+                            "env_vars": ["OPENAI_API_KEY"],
+                            "strict": True,
                         },
-                        'tools': None,
-                        'tools_strict': False
-                    }
-                }
+                        "tools": None,
+                        "tools_strict": False,
+                    },
+                },
             },
-            'connections': [
+            "connections": [
                 {
-                    'sender': 'invoker.tool_messages',
-                    'receiver': 'chatgenerator.messages'
+                    "sender": "invoker.tool_messages",
+                    "receiver": "chatgenerator.messages",
                 }
-            ]
+            ],
         }
 
         pipeline_yaml = pipeline.dumps()
 
         new_pipeline = Pipeline.loads(pipeline_yaml)
-        assert new_pipeline==pipeline
+        assert new_pipeline == pipeline


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/6012

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds support for async in `OpenAIChatGenerator`. Also includes a couple of unrelated changes/fixes:
- Fix missing init params `timeout` and `max_retries` in serde.
- Update the default model to `gpt-4o-mini` in line with the core package.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit and integration tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
