### PR TITLE
docs: AutoMerging Retriever now supports AstraDB

### DIFF
--- a/haystack_experimental/components/retrievers/auto_merging_retriever.py
+++ b/haystack_experimental/components/retrievers/auto_merging_retriever.py
@@ -27,6 +27,7 @@ class AutoMergingRetriever:
     chunks alone.
 
     Currently the AutoMergingRetriever can only be used by the following DocumentStores:
+    - [AstraDB](https://haystack.deepset.ai/integrations/astradb)
     - [ElasticSearch](https://haystack.deepset.ai/docs/latest/documentstore/elasticsearch)
     - [OpenSearch](https://haystack.deepset.ai/docs/latest/documentstore/opensearch)
     - [PGVector](https://haystack.deepset.ai/docs/latest/documentstore/pgvector)


### PR DESCRIPTION
- AstraDB is now also supported by the AutoMergingRetreiver

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
