### PR TITLE
feat: Implement async version of `InMemoryDocumentStore`

### DIFF
--- a/haystack_experimental/document_stores/in_memory/__init__.py
+++ b/haystack_experimental/document_stores/in_memory/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .document_store import InMemoryDocumentStore
+
+__all__ = ["InMemoryDocumentStore"]

--- a/haystack_experimental/document_stores/in_memory/document_store.py
+++ b/haystack_experimental/document_stores/in_memory/document_store.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Literal, Optional
+
+from haystack.dataclasses import Document
+from haystack.document_stores.in_memory.document_store import (
+    InMemoryDocumentStore as InMemoryDocumentStoreBase,
+)
+from haystack.document_stores.types import DuplicatePolicy
+
+
+class InMemoryDocumentStore(InMemoryDocumentStoreBase):
+    """
+    Asynchronous version of the in-memory document store.
+    """
+
+    def __init__(
+        self,
+        bm25_tokenization_regex: str = r"(?u)\b\w\w+\b",
+        bm25_algorithm: Literal["BM25Okapi", "BM25L", "BM25Plus"] = "BM25L",
+        bm25_parameters: Optional[Dict] = None,
+        embedding_similarity_function: Literal["dot_product", "cosine"] = "dot_product",
+        index: Optional[str] = None,
+        async_executor: Optional[ThreadPoolExecutor] = None,
+    ):
+        """
+        Initializes the DocumentStore.
+
+        :param bm25_tokenization_regex: The regular expression used to tokenize the text for BM25 retrieval.
+        :param bm25_algorithm: The BM25 algorithm to use. One of "BM25Okapi", "BM25L", or "BM25Plus".
+        :param bm25_parameters: Parameters for BM25 implementation in a dictionary format.
+            For example: {'k1':1.5, 'b':0.75, 'epsilon':0.25}
+            You can learn more about these parameters by visiting https://github.com/dorianbrown/rank_bm25.
+        :param embedding_similarity_function: The similarity function used to compare Documents embeddings.
+            One of "dot_product" (default) or "cosine". To choose the most appropriate function, look for information
+            about your embedding model.
+        :param index: A specific index to store the documents. If not specified, a random UUID is used.
+            Using the same index allows you to store documents across multiple InMemoryDocumentStore instances.
+        :param async_executor:
+            Optional ThreadPoolExecutor to use for async calls. If not provided, a single-threaded
+            executor will initialized and used.
+        """
+        super().__init__(
+            bm25_tokenization_regex=bm25_tokenization_regex,
+            bm25_algorithm=bm25_algorithm,
+            bm25_parameters=bm25_parameters,
+            embedding_similarity_function=embedding_similarity_function,
+            index=index,
+        )
+
+        self.executor = (
+            ThreadPoolExecutor(
+                thread_name_prefix=f"async-inmemory-docstore-executor-{id(self)}",
+                max_workers=1,
+            )
+            if async_executor is None
+            else async_executor
+        )
+
+    async def count_documents_async(self) -> int:
+        """
+        Returns the number of how many documents are present in the DocumentStore.
+        """
+        return len(self.storage.keys())
+
+    async def filter_documents_async(
+        self, filters: Optional[Dict[str, Any]] = None
+    ) -> List[Document]:
+        """
+        Returns the documents that match the filters provided.
+
+        For a detailed specification of the filters, refer to the DocumentStore.filter_documents() protocol
+        documentation.
+
+        :param filters: The filters to apply to the document list.
+        :returns: A list of Documents that match the given filters.
+        """
+        return await asyncio.get_event_loop().run_in_executor(
+            self.executor, lambda: self.filter_documents(filters=filters)
+        )
+
+    async def write_documents_async(
+        self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE
+    ) -> int:
+        """
+        Refer to the DocumentStore.write_documents() protocol documentation.
+
+        If `policy` is set to `DuplicatePolicy.NONE` defaults to `DuplicatePolicy.FAIL`.
+        """
+        return await asyncio.get_event_loop().run_in_executor(
+            self.executor,
+            lambda: self.write_documents(documents=documents, policy=policy),
+        )
+
+    async def delete_documents_async(self, document_ids: List[str]) -> None:
+        """
+        Deletes all documents with matching document_ids from the DocumentStore.
+
+        :param document_ids: The object_ids to delete.
+        """
+        await asyncio.get_event_loop().run_in_executor(
+            self.executor,
+            lambda: self.delete_documents(document_ids=document_ids),
+        )
+
+    async def bm25_retrieval_async(
+        self,
+        query: str,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = False,
+    ) -> List[Document]:
+        """
+        Retrieves documents that are most relevant to the query using BM25 algorithm.
+
+        :param query: The query string.
+        :param filters: A dictionary with filters to narrow down the search space.
+        :param top_k: The number of top documents to retrieve. Default is 10.
+        :param scale_score: Whether to scale the scores of the retrieved documents. Default is False.
+        :returns: A list of the top_k documents most relevant to the query.
+        """
+        return await asyncio.get_event_loop().run_in_executor(
+            self.executor,
+            lambda: self.bm25_retrieval(
+                query=query, filters=filters, top_k=top_k, scale_score=scale_score
+            ),
+        )
+
+    async def embedding_retrieval_async(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = False,
+        return_embedding: bool = False,
+    ) -> List[Document]:
+        """
+        Retrieves documents that are most similar to the query embedding using a vector similarity metric.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: A dictionary with filters to narrow down the search space.
+        :param top_k: The number of top documents to retrieve. Default is 10.
+        :param scale_score: Whether to scale the scores of the retrieved Documents. Default is False.
+        :param return_embedding: Whether to return the embedding of the retrieved Documents. Default is False.
+        :returns: A list of the top_k documents most relevant to the query.
+        """
+        return await asyncio.get_event_loop().run_in_executor(
+            self.executor,
+            lambda: self.embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                scale_score=scale_score,
+                return_embedding=return_embedding,
+            ),
+        )

--- a/haystack_experimental/document_stores/types/protocol.py
+++ b/haystack_experimental/document_stores/types/protocol.py
@@ -38,7 +38,8 @@ class DocumentStore(Protocol):
         """
         ...
 
-    async def count_documents_async(self) -> int: ...  # noqa: D102
+    async def count_documents_async(self) -> int:  # noqa: D102
+        ...
 
     def filter_documents(
         self, filters: Optional[Dict[str, Any]] = None

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+import tempfile
+
+from haystack import Document
+from haystack.document_stores.errors import DuplicateDocumentError
+from haystack_experimental.document_stores.in_memory import InMemoryDocumentStore
+from haystack.testing.document_store import DocumentStoreBaseTests
+
+
+class TestMemoryDocumentStoreAsync(DocumentStoreBaseTests):  # pylint: disable=R0904
+    """
+    Test InMemoryDocumentStore's specific features
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield tmp_dir
+
+    @pytest.fixture
+    def document_store(self) -> InMemoryDocumentStore:
+        return InMemoryDocumentStore(bm25_algorithm="BM25L")
+
+    def test_to_dict(self):
+        store = InMemoryDocumentStore()
+        data = store.to_dict()
+        assert data == {
+            "type": "haystack_experimental.document_stores.in_memory.document_store.InMemoryDocumentStore",
+            "init_parameters": {
+                "bm25_tokenization_regex": r"(?u)\b\w\w+\b",
+                "bm25_algorithm": "BM25L",
+                "bm25_parameters": {},
+                "embedding_similarity_function": "dot_product",
+                "index": store.index,
+            },
+        }
+
+    def test_to_dict_with_custom_init_parameters(self):
+        store = InMemoryDocumentStore(
+            bm25_tokenization_regex="custom_regex",
+            bm25_algorithm="BM25Plus",
+            bm25_parameters={"key": "value"},
+            embedding_similarity_function="cosine",
+            index="my_cool_index",
+        )
+        data = store.to_dict()
+        assert data == {
+            "type": "haystack_experimental.document_stores.in_memory.document_store.InMemoryDocumentStore",
+            "init_parameters": {
+                "bm25_tokenization_regex": "custom_regex",
+                "bm25_algorithm": "BM25Plus",
+                "bm25_parameters": {"key": "value"},
+                "embedding_similarity_function": "cosine",
+                "index": "my_cool_index",
+            },
+        }
+
+    @patch("haystack.document_stores.in_memory.document_store.re")
+    def test_from_dict(self, mock_regex):
+        data = {
+            "type": "haystack_experimental.document_stores.in_memory.document_store.InMemoryDocumentStore",
+            "init_parameters": {
+                "bm25_tokenization_regex": "custom_regex",
+                "bm25_algorithm": "BM25Plus",
+                "bm25_parameters": {"key": "value"},
+                "index": "my_cool_index",
+            },
+        }
+        store = InMemoryDocumentStore.from_dict(data)
+        mock_regex.compile.assert_called_with("custom_regex")
+        assert store.tokenizer
+        assert store.bm25_algorithm == "BM25Plus"
+        assert store.bm25_parameters == {"key": "value"}
+        assert store.index == "my_cool_index"
+
+    @pytest.mark.asyncio
+    async def test_write_documents(self, document_store: InMemoryDocumentStore):
+        docs = [Document(id="1")]
+        assert await document_store.write_documents_async(docs) == 1
+        with pytest.raises(DuplicateDocumentError):
+            await document_store.write_documents_async(docs)
+
+    @pytest.mark.asyncio
+    async def test_count_documents(self, document_store: InMemoryDocumentStore):
+        await document_store.write_documents_async(
+            [
+                Document(content="test doc 1"),
+                Document(content="test doc 2"),
+                Document(content="test doc 3"),
+            ]
+        )
+        assert await document_store.count_documents_async() == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_documents(self, document_store: InMemoryDocumentStore):
+        filterable_docs = [
+            Document(
+                content=f"1",
+                meta={
+                    "number": -10,
+                },
+            ),
+            Document(
+                content=f"2",
+                meta={
+                    "number": 100,
+                },
+            ),
+        ]
+        await document_store.write_documents_async(filterable_docs)
+        result = await document_store.filter_documents_async(
+            filters={"field": "meta.number", "operator": "==", "value": 100}
+        )
+        DocumentStoreBaseTests().assert_documents_are_equal(
+            result, [d for d in filterable_docs if d.meta.get("number") == 100]
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_documents(self, document_store: InMemoryDocumentStore):
+        doc = Document(content="test doc")
+        await document_store.write_documents_async([doc])
+        assert document_store.count_documents() == 1
+
+        await document_store.delete_documents_async([doc.id])
+        assert await document_store.count_documents_async() == 0
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval(self, document_store: InMemoryDocumentStore):
+        # Tests if the bm25_retrieval method returns the correct document based on the input query.
+        docs = [
+            Document(content="Hello world"),
+            Document(content="Haystack supports multiple languages"),
+        ]
+        await document_store.write_documents_async(docs)
+        results = await document_store.bm25_retrieval_async(
+            query="What languages?", top_k=1
+        )
+        assert len(results) == 1
+        assert results[0].content == "Haystack supports multiple languages"
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval(self):
+        docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(
+                content="Haystack supports multiple languages",
+                embedding=[1.0, 1.0, 1.0, 1.0],
+            ),
+        ]
+        await docstore.write_documents_async(docs)
+        results = await docstore.embedding_retrieval_async(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters={}, scale_score=False
+        )
+        assert len(results) == 1
+        assert results[0].content == "Haystack supports multiple languages"


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/6012

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add support for async in `InMemoryDocumentStore`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
CI will fail due to a dependency on core 2.6.0. Test locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
