### PR TITLE
feat: Implement async support in `DocumentWriter`

### DIFF
--- a/docs/pydoc/config/writers_api.yml
+++ b/docs/pydoc/config/writers_api.yml
@@ -1,7 +1,11 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../]
-    modules: ["haystack_experimental.components.writers.chat_message_writer"]
+    modules:
+      [
+        "haystack_experimental.components.writers.chat_message_writer",
+        "haystack_experimental.components.writers.document_writer",
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/haystack_experimental/components/writers/__init__.py
+++ b/haystack_experimental/components/writers/__init__.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack_experimental.components.writers.chat_message_writer import ChatMessageWriter
+from haystack_experimental.components.writers.chat_message_writer import (
+    ChatMessageWriter,
+)
+from haystack_experimental.components.writers.document_writer import DocumentWriter
 
-_all_ = ["ChatMessageWriter"]
+_all_ = ["ChatMessageWriter", "DocumentWriter"]

--- a/haystack_experimental/components/writers/document_writer.py
+++ b/haystack_experimental/components/writers/document_writer.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+from haystack import Document, component, logging
+from haystack.components.writers import DocumentWriter as DocumentWriterBase
+from haystack.document_stores.types import DuplicatePolicy
+
+from haystack_experimental.document_stores.types import DocumentStore
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class DocumentWriter(DocumentWriterBase):
+    """
+    Writes documents to a DocumentStore.
+
+    ### Usage example
+    ```python
+    from haystack import Document
+    from haystack.components.writers import DocumentWriter
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+    docs = [
+        Document(content="Python is a popular programming language"),
+    ]
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(docs)
+    ```
+    """
+
+    def __init__(
+        self,
+        document_store: DocumentStore,
+        policy: DuplicatePolicy = DuplicatePolicy.NONE,
+    ):
+        """
+        Create a DocumentWriter component.
+
+        :param document_store:
+            The instance of the document store where you want to store your documents.
+        :param policy:
+            The policy to apply when a Document with the same ID already exists in the DocumentStore.
+            - `DuplicatePolicy.NONE`: Default policy, relies on the DocumentStore settings.
+            - `DuplicatePolicy.SKIP`: Skips documents with the same ID and doesn't write them to the DocumentStore.
+            - `DuplicatePolicy.OVERWRITE`: Overwrites documents with the same ID.
+            - `DuplicatePolicy.FAIL`: Raises an error if a Document with the same ID is already in the DocumentStore.
+        """
+        super(DocumentWriter, self).__init__(
+            document_store=document_store, policy=policy
+        )
+
+    @component.output_types(documents_written=int)
+    async def run_async(
+        self, documents: List[Document], policy: Optional[DuplicatePolicy] = None
+    ):
+        """
+        Run the DocumentWriter on the given input data.
+
+        :param documents:
+            A list of documents to write to the document store.
+        :param policy:
+            The policy to use when encountering duplicate documents.
+        :returns:
+            Number of documents written to the document store.
+
+        :raises ValueError:
+            If the specified document store is not found.
+        """
+        if policy is None:
+            policy = self.policy
+
+        if not hasattr(self.document_store, "write_documents_async"):
+            raise TypeError(
+                f"Document store {type(self.document_store).__name__} does not provide async support."
+            )
+
+        documents_written = await self.document_store.write_documents_async(  # type: ignore
+            documents=documents, policy=policy
+        )
+        return {"documents_written": documents_written}

--- a/test/components/writers/test_document_writer.py
+++ b/test/components/writers/test_document_writer.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from haystack import Document
+from haystack.testing.factory import document_store_class
+from haystack_experimental.components.writers.document_writer import DocumentWriter
+from haystack.document_stores.types import DuplicatePolicy
+from haystack_experimental.document_stores.in_memory import InMemoryDocumentStore
+
+
+class TestDocumentWriter:
+    @pytest.mark.asyncio
+    async def test_run_invalid_docstore(self):
+        document_store = document_store_class("MockedDocumentStore")
+
+        writer = DocumentWriter(document_store)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        with pytest.raises(TypeError, match="does not provide async support"):
+            result = await writer.run_async(documents=documents)
+
+    @pytest.mark.asyncio
+    async def test_run(self):
+        document_store = InMemoryDocumentStore()
+        writer = DocumentWriter(document_store)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 2
+
+    @pytest.mark.asyncio
+    async def test_run_skip_policy(self):
+        document_store = InMemoryDocumentStore()
+        writer = DocumentWriter(document_store, policy=DuplicatePolicy.SKIP)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 2
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 0


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/6012

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds async support to the `DocumentWriter` component

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
CI will fail until 2.6.0 is out. Test locally with `haystack@main`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
