### PR TITLE
chore: replace `max_loops_allowed` with `max_runs_per_component` in tests

### DIFF
--- a/test/components/splitters/test_hierarchical_doc_splitter.py
+++ b/test/components/splitters/test_hierarchical_doc_splitter.py
@@ -99,7 +99,7 @@ class TestHierarchicalDocumentSplitter:
         pipeline.connect("hierarchical_doc_splitter", "doc_writer")
         expected = pipeline.to_dict()
 
-        assert expected.keys() == {"metadata", "max_loops_allowed", "components", "connections"}
+        assert expected.keys() == {"metadata", "max_runs_per_component", "components", "connections"}
         assert expected["components"].keys() == {"hierarchical_doc_splitter", "doc_writer"}
         assert expected["components"]["hierarchical_doc_splitter"] == {
             "type": "haystack_experimental.components.splitters.hierarchical_doc_splitter.HierarchicalDocumentSplitter",
@@ -109,7 +109,7 @@ class TestHierarchicalDocumentSplitter:
     def test_from_dict_in_pipeline(self):
         data = {
             "metadata": {},
-            "max_loops_allowed": 100,
+            "max_runs_per_component": 100,
             "components": {
                 "hierarchical_doc_splitter": {
                     "type": "haystack_experimental.components.splitters.hierarchical_doc_splitter.HierarchicalDocumentSplitter",

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -269,7 +269,7 @@ class TestToolInvoker:
         pipeline_dict = pipeline.to_dict()
         assert pipeline_dict == {
             'metadata': {},
-            'max_loops_allowed': 100,
+            'max_runs_per_component': 100,
             'components': {
                 'invoker': {
                     'type': 'haystack_experimental.components.tools.tool_invoker.ToolInvoker',


### PR DESCRIPTION
### Related Issues
https://github.com/deepset-ai/haystack/pull/8354

Some tests are failing due to the renaming of this argument: https://github.com/deepset-ai/haystack-experimental/actions/runs/11162240813/job/31026461862?pr=114

### Proposed Changes:
Rename the argument in tests, too

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
