### PR TITLE
feat: Add async support to `OpenSearchEmbeddingRetreiver`

### DIFF
--- a/haystack_experimental/components/retrievers/opensearch/__init__.py
+++ b/haystack_experimental/components/retrievers/opensearch/__init__.py
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .bm25_retriever import OpenSearchBM25Retriever
+from .embedding_retriever import OpenSearchEmbeddingRetriever
 
-__all__ = ["OpenSearchBM25Retriever"]
+__all__ = ["OpenSearchBM25Retriever", "OpenSearchEmbeddingRetriever"]

--- a/haystack_experimental/components/retrievers/opensearch/bm25_retriever.py
+++ b/haystack_experimental/components/retrievers/opensearch/bm25_retriever.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 @component
 class OpenSearchBM25Retriever:
     """
-    Fetches documents from OpenSearchDocumentStore using the keyword-based BM25 algorithm.
-
-    BM25 computes a weighted word overlap between the query string and a document to determine its similarity.
+    OpenSearch BM25 retriever with async support.
     """
 
     def __init__(
@@ -231,8 +229,8 @@ class OpenSearchBM25Retriever:
                 raise e
             else:
                 logger.warning(
-                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: %s",
-                    str(e),
+                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: {error}",
+                    error=str(e),
                     exc_info=True,
                 )
 
@@ -287,8 +285,8 @@ class OpenSearchBM25Retriever:
                 raise e
             else:
                 logger.warning(
-                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: %s",
-                    str(e),
+                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: {error}",
+                    error=str(e),
                     exc_info=True,
                 )
 

--- a/haystack_experimental/components/retrievers/opensearch/embedding_retriever.py
+++ b/haystack_experimental/components/retrievers/opensearch/embedding_retriever.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, List, Optional, Union
+
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.dataclasses import Document
+from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types.filter_policy import apply_filter_policy
+
+from haystack_experimental.document_stores.opensearch import OpenSearchDocumentStore
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class OpenSearchEmbeddingRetriever:
+    """
+    OpenSearch embedding retriever with async support.
+    """
+
+    def __init__(
+        self,
+        *,
+        document_store: OpenSearchDocumentStore,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        custom_query: Optional[Dict[str, Any]] = None,
+        raise_on_failure: bool = True,
+    ):
+        """
+        Create the OpenSearchEmbeddingRetriever component.
+
+        :param document_store: An instance of OpenSearchDocumentStore to use with the Retriever.
+        :param filters: Filters applied when fetching documents from the Document Store.
+            Filters are applied during the approximate kNN search to ensure the Retriever returns
+              `top_k` matching documents.
+        :param top_k: Maximum number of documents to return.
+        :param filter_policy: Policy to determine how filters are applied. Possible options:
+        - `merge`: Runtime filters are merged with initialization filters.
+        - `replace`: Runtime filters replace initialization filters. Use this policy to change the filtering scope.
+        :param custom_query: The custom OpenSearch query containing a mandatory `$query_embedding` and
+          an optional `$filters` placeholder.
+        :param raise_on_failure:
+            If `True`, raises an exception if the API call fails.
+            If `False`, logs a warning and returns an empty list.
+
+        :raises ValueError: If `document_store` is not an instance of OpenSearchDocumentStore.
+        """
+        if not isinstance(document_store, OpenSearchDocumentStore):
+            msg = "document_store must be an instance of OpenSearchDocumentStore"
+            raise ValueError(msg)
+
+        self._document_store = document_store
+        self._filters = filters or {}
+        self._top_k = top_k
+        self._filter_policy = (
+            filter_policy
+            if isinstance(filter_policy, FilterPolicy)
+            else FilterPolicy.from_str(filter_policy)
+        )
+        self._custom_query = custom_query
+        self._raise_on_failure = raise_on_failure
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            filters=self._filters,
+            top_k=self._top_k,
+            document_store=self._document_store.to_dict(),
+            filter_policy=self._filter_policy.value,
+            custom_query=self._custom_query,
+            raise_on_failure=self._raise_on_failure,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OpenSearchEmbeddingRetriever":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            Dictionary to deserialize from.
+
+        :returns:
+            Deserialized component.
+        """
+        data["init_parameters"]["document_store"] = OpenSearchDocumentStore.from_dict(
+            data["init_parameters"]["document_store"]
+        )
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Retrieve documents using a vector similarity metric.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: Filters applied when fetching documents from the Document Store.
+            Filters are applied during the approximate kNN search to ensure the Retriever
+              returns `top_k` matching documents.
+            The way runtime filters are applied depends on the `filter_policy` selected when initializing the Retriever.
+        :param top_k: Maximum number of documents to return.
+        :param custom_query: A custom OpenSearch query containing a mandatory `$query_embedding` and an
+          optional `$filters` placeholder.
+        :returns:
+            Dictionary with key "documents" containing the retrieved Documents.
+            - documents: List of Document similar to `query_embedding`.
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+        top_k = top_k or self._top_k
+        if filters is None:
+            filters = self._filters
+        if top_k is None:
+            top_k = self._top_k
+        if custom_query is None:
+            custom_query = self._custom_query
+
+        docs: List[Document] = []
+
+        try:
+            docs = self._document_store._embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                custom_query=custom_query,
+            )
+        except Exception as e:
+            if self._raise_on_failure:
+                raise e
+            else:
+                logger.warning(
+                    "An error during embedding retrieval occurred and will be ignored by returning empty results: {error}",
+                    error=str(e),
+                    exc_info=True,
+                )
+
+        return {"documents": docs}
+
+    @component.output_types(documents=List[Document])
+    async def run_async(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Retrieve documents using a vector similarity metric.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: Filters applied when fetching documents from the Document Store.
+            Filters are applied during the approximate kNN search to ensure the Retriever
+              returns `top_k` matching documents.
+            The way runtime filters are applied depends on the `filter_policy` selected when initializing the Retriever.
+        :param top_k: Maximum number of documents to return.
+        :param custom_query: A custom OpenSearch query containing a mandatory `$query_embedding` and an
+          optional `$filters` placeholder.
+        :returns:
+            Dictionary with key "documents" containing the retrieved Documents.
+            - documents: List of Document similar to `query_embedding`.
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+        top_k = top_k or self._top_k
+        if filters is None:
+            filters = self._filters
+        if top_k is None:
+            top_k = self._top_k
+        if custom_query is None:
+            custom_query = self._custom_query
+
+        docs: List[Document] = []
+
+        try:
+            docs = await self._document_store._embedding_retrieval_async(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                custom_query=custom_query,
+            )
+        except Exception as e:
+            if self._raise_on_failure:
+                raise e
+            else:
+                logger.warning(
+                    "An error during embedding retrieval occurred and will be ignored by returning empty results: {error}",
+                    error=str(e),
+                    exc_info=True,
+                )
+
+        return {"documents": docs}

--- a/test/components/retrievers/opensearch/test_embedding_retriever.py
+++ b/test/components/retrievers/opensearch/test_embedding_retriever.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock, patch
+
+import pytest
+from haystack.dataclasses import Document
+from haystack.document_stores.types import FilterPolicy
+
+from haystack_experimental.components.retrievers.opensearch import (
+    OpenSearchEmbeddingRetriever,
+)
+from haystack_experimental.document_stores.opensearch import OpenSearchDocumentStore
+from haystack_experimental.document_stores.opensearch.document_store import (
+    DEFAULT_MAX_CHUNK_BYTES,
+)
+
+
+def test_init_default():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+    assert retriever._document_store == mock_store
+    assert retriever._filters == {}
+    assert retriever._top_k == 10
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store, filter_policy="replace"
+    )
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
+    with pytest.raises(ValueError):
+        OpenSearchEmbeddingRetriever(document_store=mock_store, filter_policy="unknown")
+
+
+@patch("haystack_experimental.document_stores.opensearch.document_store.OpenSearch")
+def test_to_dict(_mock_opensearch_client):
+    document_store = OpenSearchDocumentStore(hosts="some fake host")
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=document_store, custom_query={"some": "custom query"}
+    )
+    res = retriever.to_dict()
+    type_s = "haystack_experimental.components.retrievers.opensearch.embedding_retriever.OpenSearchEmbeddingRetriever"
+    assert res == {
+        "type": type_s,
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {
+                    "embedding_dim": 768,
+                    "hosts": "some fake host",
+                    "index": "default",
+                    "mappings": {
+                        "dynamic_templates": [
+                            {
+                                "strings": {
+                                    "mapping": {
+                                        "type": "keyword",
+                                    },
+                                    "match_mapping_type": "string",
+                                },
+                            },
+                        ],
+                        "properties": {
+                            "content": {
+                                "type": "text",
+                            },
+                            "embedding": {
+                                "dimension": 768,
+                                "index": True,
+                                "type": "knn_vector",
+                            },
+                        },
+                    },
+                    "max_chunk_bytes": DEFAULT_MAX_CHUNK_BYTES,
+                    "method": None,
+                    "settings": {
+                        "index.knn": True,
+                    },
+                    "return_embedding": False,
+                    "create_index": True,
+                    "http_auth": None,
+                    "use_ssl": None,
+                    "verify_certs": None,
+                    "timeout": None,
+                },
+                "type": "haystack_experimental.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+            "filter_policy": "replace",
+            "custom_query": {"some": "custom query"},
+            "raise_on_failure": True,
+        },
+    }
+
+
+@patch("haystack_experimental.document_stores.opensearch.document_store.OpenSearch")
+def test_from_dict(_mock_opensearch_client):
+    type_s = "haystack_experimental.components.retrievers.opensearch.embedding_retriever.OpenSearchEmbeddingRetriever"
+    data = {
+        "type": type_s,
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_experimental.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+            "filter_policy": "replace",
+            "custom_query": {"some": "custom query"},
+            "raise_on_failure": False,
+        },
+    }
+    retriever = OpenSearchEmbeddingRetriever.from_dict(data)
+    assert retriever._document_store
+    assert retriever._filters == {}
+    assert retriever._top_k == 10
+    assert retriever._custom_query == {"some": "custom query"}
+    assert retriever._raise_on_failure is False
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
+    # For backwards compatibility with older versions of the retriever without a filter policy
+    data = {
+        "type": type_s,
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_experimental.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+            "custom_query": {"some": "custom query"},
+            "raise_on_failure": False,
+        },
+    }
+    retriever = OpenSearchEmbeddingRetriever.from_dict(data)
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
+
+def test_run():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+    res = retriever.run(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={},
+        top_k=10,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_run_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+    res = await retriever.run_async(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={},
+        top_k=10,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+def test_run_init_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store,
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+    )
+    res = retriever.run(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_run_async_init_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store,
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+    )
+    res = await retriever.run_async(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+def test_run_time_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store, filters={"from": "init"}, top_k=11
+    )
+    res = retriever.run(query_embedding=[0.5, 0.7], filters={"from": "run"}, top_k=9)
+    mock_store._embedding_retrieval.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "run"},
+        top_k=9,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_run_async_time_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [
+        Document(content="Test doc", embedding=[0.1, 0.2])
+    ]
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store, filters={"from": "init"}, top_k=11
+    )
+    res = await retriever.run_async(
+        query_embedding=[0.5, 0.7], filters={"from": "run"}, top_k=9
+    )
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "run"},
+        top_k=9,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+def test_run_ignore_errors(caplog):
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval.side_effect = Exception("Some error")
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store, raise_on_failure=False
+    )
+    res = retriever.run(query_embedding=[0.5, 0.7])
+    assert len(res) == 1
+    assert res["documents"] == []
+    assert "Some error" in caplog.text


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/6012

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add support for async to the `OpenSearchEmbeddingRetriever` and some minor bug fixes.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
Test failures should be unrelated; lints will be fixed when the feature branch is merged into `main`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
