### PR TITLE
fix: update `OllamaChatGenerator` with `keep_alive` parameter

### DIFF
--- a/haystack_experimental/components/generators/ollama/chat/chat_generator.py
+++ b/haystack_experimental/components/generators/ollama/chat/chat_generator.py
@@ -253,7 +253,7 @@ class OllamaChatGenerator(chatgenerator_base_class):
             tools=ollama_tools,
             stream=stream,
             keep_alive=self.keep_alive,
-            generation_kwargs=generation_kwargs,
+            options=generation_kwargs,
         )
 
         if stream:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ extra-dependencies = [
   "fastapi",
   # Tools support
   "jsonschema",
-  "ollama-haystack>=1.0.0",
+  "ollama-haystack>=1.1.0",
   # LLMMetadataExtractor dependencies
   "amazon-bedrock-haystack>=1.0.2",
   "google-vertex-haystack>=2.0.0",

--- a/test/components/generators/ollama/test_chat_generator.py
+++ b/test/components/generators/ollama/test_chat_generator.py
@@ -105,6 +105,7 @@ class TestOllamaChatGenerator:
         assert component.timeout == 120
         assert component.streaming_callback is None
         assert component.tools is None
+        assert component.keep_alive is None
 
     def test_init(self, tools):
         component = OllamaChatGenerator(
@@ -112,6 +113,7 @@ class TestOllamaChatGenerator:
             url="http://my-custom-endpoint:11434",
             generation_kwargs={"temperature": 0.5},
             timeout=5,
+            keep_alive="10m",
             streaming_callback=print_streaming_chunk,
             tools=tools,
         )
@@ -120,6 +122,7 @@ class TestOllamaChatGenerator:
         assert component.url == "http://my-custom-endpoint:11434"
         assert component.generation_kwargs == {"temperature": 0.5}
         assert component.timeout == 5
+        assert component.keep_alive == "10m"
         assert component.streaming_callback is print_streaming_chunk
         assert component.tools == tools
 
@@ -143,6 +146,7 @@ class TestOllamaChatGenerator:
             url="custom_url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
             tools=[tool],
+            keep_alive="5m",
         )
         data = component.to_dict()
         assert data == {
@@ -152,6 +156,7 @@ class TestOllamaChatGenerator:
                 "model": "llama2",
                 "url": "custom_url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "keep_alive": "5m",
                 "generation_kwargs": {
                     "max_tokens": 10,
                     "some_test_param": "test-params",
@@ -185,6 +190,7 @@ class TestOllamaChatGenerator:
                 "timeout": 120,
                 "model": "llama2",
                 "url": "custom_url",
+                "keep_alive": "5m",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {
                     "max_tokens": 10,
@@ -208,6 +214,7 @@ class TestOllamaChatGenerator:
         assert component.model == "llama2"
         assert component.streaming_callback is print_streaming_chunk
         assert component.url == "custom_url"
+        assert component.keep_alive == "5m"
         assert component.generation_kwargs == {
             "max_tokens": 10,
             "some_test_param": "test-params",

--- a/test/components/generators/ollama/test_chat_generator.py
+++ b/test/components/generators/ollama/test_chat_generator.py
@@ -310,6 +310,7 @@ class TestOllamaChatGenerator:
             stream=False,
             tools=None,
             options={},
+            keep_alive=None,
         )
 
         assert "replies" in result


### PR DESCRIPTION
### Related Issues

- tests failing: https://github.com/deepset-ai/haystack-experimental/actions/runs/11365200366/job/31612862722?pr=118
- a new parameter was added in `OllamaChatGenerator` with https://github.com/deepset-ai/haystack-core-integrations/pull/1131

### Proposed Changes:
Adapt the experimental component to take this new parameter into account

### How did you test it?
CI, adapted tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
