### PR TITLE
ci: pin `transformers<4.46.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 
 [tool.hatch.envs.test]
 extra-dependencies = [
+  "transformers<4.46.0", # https://github.com/huggingface/transformers/issues/34370
   # RAG evaluation harness (SAS evaluator)
   "sentence-transformers>=3.0.0",
   # OpenAPI dependencies


### PR DESCRIPTION
### Related Issues
Tests in PRs are failing: https://github.com/deepset-ai/haystack-experimental/actions/runs/11498274042/job/32003723182?pr=125

This is due to the release of `transformers==4.46.0`, which has a type hint incompatible with Python<3.9
https://github.com/huggingface/transformers/issues/34370

We were not pinning `transformers` in this repository, so we get the latest version.

(We should soon drop support for python 3.8, which reached EOL.)

### Proposed Changes:
Pin `transformers<4.46.0`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
