### PR TITLE
ci: test with Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ on:
       - "pyproject.toml"
 
 env:
-  PYTHON_VERSION: "3.8"
+  PYTHON_VERSION: "3.9"
   HATCH_VERSION: "1.13.0"
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"


### PR DESCRIPTION
### Related Issues
- Python 3.8 already reached End Of Life
- We are testing Haystack with Python 3.9 (https://github.com/deepset-ai/haystack/pull/8492) 

### Proposed Changes:
- use Python 3.9 in CI

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
