### PR TITLE
fix: Update mock components in eval harness test to correctly serialize their params

### DIFF
--- a/test/evaluation/harness/rag/test_harness.py
+++ b/test/evaluation/harness/rag/test_harness.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 import pytest
 
 from haystack_experimental.evaluation.harness.rag import (
@@ -106,7 +106,9 @@ class MockKeywordRetriever:
 
 @component
 class MockEvaluator:
-    def __init__(self, metric: RAGEvaluationMetric) -> None:
+    def __init__(self, metric: Union[str, RAGEvaluationMetric]) -> None:
+        if isinstance(metric, str):
+            metric = RAGEvaluationMetric(metric)
         self.metric = metric
 
         io_map = {
@@ -131,6 +133,9 @@ class MockEvaluator:
 
         self.__haystack_input__ = io_map[metric].__haystack_input__
         self.__haystack_output__ = io_map[metric].__haystack_output__
+
+    def to_dict(self):
+        return default_to_dict(self, metric=str(self.metric))
 
     @staticmethod
     def default_output(metric) -> Dict[str, Any]:


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
To accommodate the recent Haystack [PR](https://github.com/deepset-ai/haystack/pull/8473) related to serialization constraints.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
