### PR TITLE
fix: OpenAI Chat Generator - do not create `TextContent` if `content` is `None`; make Anthropic Chat Generator more robust

### DIFF
--- a/haystack_experimental/components/generators/anthropic/chat/chat_generator.py
+++ b/haystack_experimental/components/generators/anthropic/chat/chat_generator.py
@@ -119,7 +119,7 @@ def _convert_messages_to_anthropic_format(
 
         anthropic_msg: Dict[str, Any] = {"role": message._role.value, "content": []}
 
-        if message.texts:
+        if message.texts and message.texts[0]:
             anthropic_msg["content"].append({"type": "text", "text": message.texts[0]})
         if message.tool_calls:
             anthropic_msg["content"] += _convert_tool_calls_to_anthropic_format(message.tool_calls)

--- a/haystack_experimental/components/generators/chat/openai.py
+++ b/haystack_experimental/components/generators/chat/openai.py
@@ -362,7 +362,7 @@ class OpenAIChatGenerator(OpenAIChatGeneratorBase):
         :return: The ChatMessage.
         """
         message: ChatCompletionMessage = choice.message
-        text = message.content or ""
+        text = message.content
         tool_calls = []
         if openai_tool_calls := message.tool_calls:
             for openai_tc in openai_tool_calls:

--- a/test/components/generators/anthropic/test_anthropic.py
+++ b/test/components/generators/anthropic/test_anthropic.py
@@ -643,6 +643,24 @@ class TestAnthropicChatGenerator:
             ],
         )
 
+        messages = [
+            ChatMessage.from_assistant(
+                text="",  # this should not happen, but we should handle it without errors
+                tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})]
+            )
+        ]
+        result = _convert_messages_to_anthropic_format(messages)
+        assert result == (
+            [],
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}}],
+                }
+            ],
+        )
+
+
         tool_result = json.dumps({"weather": "sunny", "temperature": "25"})
         messages = [
             ChatMessage.from_tool(

--- a/test/components/generators/anthropic/test_anthropic.py
+++ b/test/components/generators/anthropic/test_anthropic.py
@@ -739,7 +739,6 @@ class TestAnthropicChatGenerator:
             {
                 "role": "assistant",
                 "content": [
-                    {"type": "text", "text": ""},
                     {"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}},
                     {"type": "tool_use", "id": "456", "name": "math", "input": {"expression": "2+2"}},
                 ],

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -556,6 +556,9 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         message = response["replies"][0]
 
+        assert not message.texts
+        assert not message.text
+
         assert message.tool_calls
         tool_call = message.tool_call
         assert isinstance(tool_call, ToolCall)
@@ -641,6 +644,9 @@ class TestOpenAIChatGenerator:
         assert len(results["replies"]) == 1
         message = results["replies"][0]
 
+
+        assert not message.texts
+        assert not message.text
         assert message.tool_calls
         tool_call = message.tool_call
         assert isinstance(tool_call, ToolCall)

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -644,7 +644,6 @@ class TestOpenAIChatGenerator:
         assert len(results["replies"]) == 1
         message = results["replies"][0]
 
-
         assert not message.texts
         assert not message.text
         assert message.tool_calls


### PR DESCRIPTION
### Related Issues
While experimenting in an application with several Chat Generators,
I encountered some errors passing `ChatMessages` generated by OpenAI to Anthropic.

Our implementation of OpenAI always creates a `TextContent`. Anthropic fails with empty text blocks.
**I think we should not create a "" `TextContent` if `content` is `None`. We should simply avoid creating it**

### Proposed Changes:
Do not create `TextContent` if `content` is `None`.

### How did you test it?
CI, enriched existing tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
