### PR TITLE
refactor: Port subgraph pipeline logic and tests to async pipelines

### DIFF
--- a/haystack_experimental/core/pipeline/async_pipeline.py
+++ b/haystack_experimental/core/pipeline/async_pipeline.py
@@ -5,20 +5,21 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from pathlib import Path
-from typing import Any, AsyncIterator, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, AsyncIterator
 from warnings import warn
+
+import networkx as nx
 
 from haystack import logging, tracing
 from haystack.core.component import Component
 from haystack.core.errors import PipelineMaxComponentRuns, PipelineRuntimeError
 from haystack.core.pipeline.base import (
     PipelineBase,
-    _add_missing_input_defaults,
     _dequeue_component,
     _dequeue_waiting_component,
     _enqueue_component,
     _enqueue_waiting_component,
+    _add_missing_input_defaults,
     _is_lazy_variadic,
 )
 from haystack.telemetry import pipeline_running
@@ -67,12 +68,19 @@ class AsyncPipeline(PipelineBase):
             else async_executor
         )
 
-    async def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    async def _run_component(
+        self,
+        name: str,
+        inputs: Dict[str, Any],
+        parent_span: Optional[tracing.Span] = None,
+    ) -> Dict[str, Any]:
         """
         Runs a Component with the given inputs.
 
         :param name: Name of the Component as defined in the Pipeline.
         :param inputs: Inputs for the Component.
+        :param parent_span: The parent span to use for the newly created span.
+            This is to allow tracing to be correctly linked to the pipeline run.
         :raises PipelineRuntimeError: If Component doesn't return a dictionary.
         :return: The output of the Component.
         """
@@ -109,8 +117,12 @@ class AsyncPipeline(PipelineBase):
                     for key, value in instance.__haystack_output__._sockets_dict.items()  # type: ignore
                 },
             },
+            parent_span=parent_span,
         ) as span:
-            span.set_content_tag("haystack.component.input", inputs)
+            # We deepcopy the inputs otherwise we might lose that information
+            # when we delete them in case they're sent to other Components
+            span.set_content_tag("haystack.component.input", deepcopy(inputs))
+            logger.info("Running component {component_name}", component_name=name)
 
             res: Dict[str, Any]
             if instance.__haystack_supports_async__:  # type: ignore
@@ -126,7 +138,6 @@ class AsyncPipeline(PipelineBase):
                 res = await asyncio.get_event_loop().run_in_executor(
                     self.executor, lambda: instance.run(**inputs)
                 )
-
             self.graph.nodes[name]["visits"] += 1
 
             # After a Component that has variadic inputs is run, we need to reset the variadic inputs that were consumed
@@ -145,6 +156,174 @@ class AsyncPipeline(PipelineBase):
             span.set_content_tag("haystack.component.output", res)
 
             return res
+
+    async def _run_subgraph(  # noqa: PLR0915
+        self,
+        cycle: List[str],
+        component_name: str,
+        components_inputs: Dict[str, Dict[str, Any]],
+    ) -> AsyncIterator[Tuple[Dict[str, Any], bool]]:
+        """
+        Runs a `cycle` in the Pipeline starting from `component_name`.
+
+        This will return once there are no inputs for the Components in `cycle`.
+
+        This is an internal method meant to be used in `Pipeline.run()` only.
+
+        :param cycle:
+            List of Components that are part of the cycle being run
+        :param component_name:
+            Name of the Component that will start execution of the cycle
+        :param components_inputs:
+            Components inputs, this might include inputs for Components that are not part
+            of the cycle but part of the wider Pipeline's graph
+        :yields:
+            Yields the individual output of each component after its execution and the final
+            outputs of all the Components that are not connected to other Components in `cycle`.
+        :raises PipelineMaxComponentRuns:
+            If a Component reaches the maximum number of times it can be run in this Pipeline
+        """
+        waiting_queue: List[Tuple[str, Component]] = []
+        run_queue: List[Tuple[str, Component]] = []
+
+        # Create the run queue starting with the component that needs to run first
+        start_index = cycle.index(component_name)
+        for node in cycle[start_index:]:
+            run_queue.append((node, self.graph.nodes[node]["instance"]))
+
+        before_last_waiting_queue: Optional[Set[str]] = None
+        last_waiting_queue: Optional[Set[str]] = None
+
+        subgraph_outputs = {}
+
+        # This variable is used to keep track if we still need to run the cycle or not.
+        # When a Component doesn't send outputs to another Component
+        # that's inside the subgraph, we stop running this subgraph.
+        cycle_received_inputs = False
+
+        while not cycle_received_inputs:
+            # Here we run the Components
+            name, comp = run_queue.pop(0)
+            if _is_lazy_variadic(comp) and not all(
+                _is_lazy_variadic(comp) for _, comp in run_queue
+            ):
+                # We run Components with lazy variadic inputs only if there only Components with
+                # lazy variadic inputs left to run
+                _enqueue_waiting_component((name, comp), waiting_queue)
+                continue
+
+            # As soon as a Component returns only output that is not part of the cycle, we can stop
+            if self._component_has_enough_inputs_to_run(name, components_inputs):
+                if self.graph.nodes[name]["visits"] > self._max_runs_per_component:
+                    msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
+                    raise PipelineMaxComponentRuns(msg)
+
+                res: Dict[str, Any] = await self._run_component(
+                    name, components_inputs[name]
+                )
+                yield {name: deepcopy(res)}, False
+
+                # Delete the inputs that were consumed by the Component and are not received from
+                # the user or from Components that are part of this cycle
+                sockets = list(components_inputs[name].keys())
+                for socket_name in sockets:
+                    senders = comp.__haystack_input__._sockets_dict[socket_name].senders  # type: ignore
+                    if not senders:
+                        # We keep inputs that came from the user
+                        continue
+                    all_senders_in_cycle = all(sender in cycle for sender in senders)
+                    if all_senders_in_cycle:
+                        # All senders are in the cycle, we can remove the input.
+                        # We'll receive it later at a certain point.
+                        del components_inputs[name][socket_name]
+
+                # Reset the waiting for input previous states, we managed to run a component
+                before_last_waiting_queue = None
+                last_waiting_queue = None
+
+                # Check if a component doesn't send any output to components that are part of the cycle
+                final_output_reached = False
+                for output_socket in res.keys():
+                    for receiver in comp.__haystack_output__._sockets_dict[output_socket].receivers:  # type: ignore
+                        if receiver in cycle:
+                            final_output_reached = True
+                            break
+                    if final_output_reached:
+                        break
+
+                if not final_output_reached:
+                    # We stop only if the Component we just ran doesn't send any output to sockets that
+                    # are part of the cycle
+                    cycle_received_inputs = True
+
+                # We manage to run this component that was in the waiting list, we can remove it.
+                # This happens when a component was put in the waiting list but we reached it from another edge.
+                _dequeue_waiting_component((name, comp), waiting_queue)
+                for pair in self._find_components_that_will_receive_no_input(
+                    name, res, components_inputs
+                ):
+                    _dequeue_component(pair, run_queue, waiting_queue)
+
+                receivers = [
+                    item for item in self._find_receivers_from(name) if item[0] in cycle
+                ]
+
+                res = self._distribute_output(
+                    receivers, res, components_inputs, run_queue, waiting_queue
+                )
+
+                # We treat a cycle as a completely independent graph, so we keep track of output
+                # that is not sent inside the cycle.
+                # This output is going to get distributed to the wider graph after we finish running
+                # a cycle.
+                # All values that are left at this point go outside the cycle.
+                if len(res) > 0:
+                    subgraph_outputs[name] = res
+            else:
+                # This component doesn't have enough inputs so we can't run it yet
+                _enqueue_waiting_component((name, comp), waiting_queue)
+
+            if len(run_queue) == 0 and len(waiting_queue) > 0:
+                # Check if we're stuck in a loop.
+                # It's important to check whether previous waitings are None as it could be that no
+                # Component has actually been run yet.
+                if (
+                    before_last_waiting_queue is not None
+                    and last_waiting_queue is not None
+                    and before_last_waiting_queue == last_waiting_queue
+                ):
+                    if self._is_stuck_in_a_loop(waiting_queue):
+                        # We're stuck! We can't make any progress.
+                        msg = (
+                            "Pipeline is stuck running in a loop. Partial outputs will be returned. "
+                            "Check the Pipeline graph for possible issues."
+                        )
+                        warn(RuntimeWarning(msg))
+                        break
+
+                    (name, comp) = (
+                        self._find_next_runnable_lazy_variadic_or_default_component(
+                            waiting_queue
+                        )
+                    )
+                    _add_missing_input_defaults(name, comp, components_inputs)
+                    _enqueue_component((name, comp), run_queue, waiting_queue)
+                    continue
+
+                before_last_waiting_queue = (
+                    last_waiting_queue.copy()
+                    if last_waiting_queue is not None
+                    else None
+                )
+                last_waiting_queue = {item[0] for item in waiting_queue}
+
+                (name, comp) = self._find_next_runnable_component(
+                    components_inputs, waiting_queue
+                )
+                _add_missing_input_defaults(name, comp, components_inputs)
+                _enqueue_component((name, comp), run_queue, waiting_queue)
+
+        yield subgraph_outputs, True
 
     async def run(  # noqa: PLR0915
         self,
@@ -209,7 +388,8 @@ class AsyncPipeline(PipelineBase):
             {"hello2": "Hello, Hello, world!"} # Output of the second component
             {"hello2": "Hello, Hello, world!"} # Final output of the pipeline
         """
-        pipeline_running(self)  # type: ignore
+
+        pipeline_running(self)
 
         # Reset the visits count for each component
         self._init_graph()
@@ -224,15 +404,10 @@ class AsyncPipeline(PipelineBase):
         # Raise if input is malformed in some way
         self._validate_input(data)
 
-        # Initialize the inputs state
-        components_inputs: Dict[str, Dict[str, Any]] = self._init_inputs_state(data)
-
-        # Take all components that:
-        # - have no inputs
-        # - receive input from the user
-        # - have at least one input not connected
-        # - have at least one input that is variadic
-        run_queue: List[Tuple[str, Component]] = self._init_run_queue(data)
+        # Normalize the input data
+        components_inputs: Dict[str, Dict[str, Any]] = (
+            self._normalize_varidiac_input_data(data)
+        )
 
         # These variables are used to detect when we're stuck in a loop.
         # Stuck loops can happen when one or more components are waiting for input but
@@ -253,6 +428,33 @@ class AsyncPipeline(PipelineBase):
         # This is what we'll return at the end
         final_outputs: Dict[Any, Any] = {}
 
+        # Break cycles in case there are, this is a noop if no cycle is found.
+        # This will raise if a cycle can't be broken.
+        graph_without_cycles, components_in_cycles = (
+            self._break_supported_cycles_in_graph()
+        )
+
+        run_queue: List[Tuple[str, Component]] = []
+        for node in nx.topological_sort(graph_without_cycles):
+            run_queue.append((node, self.graph.nodes[node]["instance"]))
+
+        # Set defaults inputs for those sockets that don't receive input neither from the user
+        # nor from other Components.
+        # If they have no default nothing is done.
+        # This is important to ensure correct order execution, otherwise some variadic
+        # Components that receive input from the user might be run before than they should.
+        for name, comp in self.graph.nodes(data="instance"):
+            if name not in components_inputs:
+                components_inputs[name] = {}
+            for socket_name, socket in comp.__haystack_input__._sockets_dict.items():
+                if socket_name in components_inputs[name]:
+                    continue
+                if not socket.senders:
+                    value = socket.default_value
+                    if socket.is_variadic:
+                        value = [value]
+                    components_inputs[name][socket_name] = value
+
         with tracing.tracer.trace(
             "haystack.pipeline.run",
             tags={
@@ -261,7 +463,7 @@ class AsyncPipeline(PipelineBase):
                 "haystack.pipeline.metadata": self.metadata,
                 "haystack.pipeline.max_runs_per_component": self._max_runs_per_component,
             },
-        ):
+        ) as span:
             while len(run_queue) > 0:
                 name, comp = run_queue.pop(0)
 
@@ -272,14 +474,64 @@ class AsyncPipeline(PipelineBase):
                     # lazy variadic inputs left to run
                     _enqueue_waiting_component((name, comp), waiting_queue)
                     continue
+                if self._component_has_enough_inputs_to_run(
+                    name, components_inputs
+                ) and components_in_cycles.get(name, []):
+                    cycles = components_in_cycles.get(name, [])
 
-                if self._component_has_enough_inputs_to_run(name, components_inputs):
+                    # This component is part of one or more cycles, let's get the first one and run it.
+                    # We can reliably pick any of the cycles if there are multiple ones, the way cycles
+                    # are run doesn't make a different whether we pick the first or any of the others a
+                    # Component is part of.
+                    async for subgraph_output, is_final_output in self._run_subgraph(
+                        cycles[0], name, components_inputs
+                    ):
+                        if not is_final_output:
+                            yield subgraph_output
+                    assert is_final_output is True
+
+                    # After a cycle is run the previous run_queue can't be correct anymore cause it's
+                    # not modified when running the subgraph.
+                    # So we reset it given the output returned by the subgraph.
+                    run_queue = []
+
+                    # Reset the waiting for input previous states, we managed to run at least one component
+                    before_last_waiting_queue = None
+                    last_waiting_queue = None
+
+                    for component_name, component_output in subgraph_output.items():
+                        receivers = self._find_receivers_from(component_name)
+                        component_output = self._distribute_output(
+                            receivers,
+                            component_output,
+                            components_inputs,
+                            run_queue,
+                            waiting_queue,
+                        )
+
+                        if len(component_output) > 0:
+                            final_outputs[component_name] = component_output
+
+                elif self._component_has_enough_inputs_to_run(name, components_inputs):
                     if self.graph.nodes[name]["visits"] > self._max_runs_per_component:
                         msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
                         raise PipelineMaxComponentRuns(msg)
 
-                    res = await self._run_component(name, components_inputs[name])
+                    res: Dict[str, Any] = await self._run_component(
+                        name, components_inputs[name], parent_span=span
+                    )
                     yield {name: deepcopy(res)}
+
+                    # Delete the inputs that were consumed by the Component and are not received from the user
+                    sockets = list(components_inputs[name].keys())
+                    for socket_name in sockets:
+                        senders = comp.__haystack_input__._sockets_dict[
+                            socket_name
+                        ].senders
+                        if senders:
+                            # Delete all inputs that are received from other Components
+                            del components_inputs[name][socket_name]
+                        # We keep inputs that came from the user
 
                     # Reset the waiting for input previous states, we managed to run a component
                     before_last_waiting_queue = None
@@ -293,8 +545,9 @@ class AsyncPipeline(PipelineBase):
                         name, res, components_inputs
                     ):
                         _dequeue_component(pair, run_queue, waiting_queue)
+                    receivers = self._find_receivers_from(name)
                     res = self._distribute_output(
-                        name, res, components_inputs, run_queue, waiting_queue
+                        receivers, res, components_inputs, run_queue, waiting_queue
                     )
 
                     if len(res) > 0:

--- a/test/core/pipeline/features/conftest.py
+++ b/test/core/pipeline/features/conftest.py
@@ -22,6 +22,7 @@ PIPELINE_NAME_REGEX = re.compile(r"\[(.*)\]")
 @dataclasses.dataclass
 class SpyingSpan(Span):
     operation_name: str
+    parent_span: Optional[Span] = None
     tags: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     trace_id: Optional[str] = dataclasses.field(
@@ -47,9 +48,12 @@ class SpyingTracer(Tracer):
 
     @contextlib.contextmanager
     def trace(
-        self, operation_name: str, tags: Optional[Dict[str, Any]] = None
+        self,
+        operation_name: str,
+        tags: Optional[Dict[str, Any]] = None,
+        parent_span: Optional[Span] = None,
     ) -> Iterator[Span]:
-        new_span = SpyingSpan(operation_name)
+        new_span = SpyingSpan(operation_name, parent_span)
 
         for key, value in (tags or {}).items():
             new_span.set_tag(key, value)

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -26,7 +26,7 @@ Feature: Pipeline running
         | that has a greedy and variadic component after a component with default input |
         | that has components added in a different order from the order of execution |
         | that has a component with only default inputs |
-        | that has a component with only default inputs as first to run |
+        | that has a component with only default inputs as first to run and receives inputs from a loop |
         | that has multiple branches that merge into a component with a single variadic input |
         | that has multiple branches of different lengths that merge into a component with a single variadic input |
         | that is linear and returns intermediate outputs |
@@ -37,6 +37,13 @@ Feature: Pipeline running
         | that has a loop and a component with default inputs that doesn't receive anything from its sender but receives input from user |
         | that has multiple components with only default inputs and are added in a different order from the order of execution |
         | that is linear with conditional branching and multiple joins |
+        | that is a simple agent |
+        | that has a variadic component that receives partial inputs |
+        | that has an answer joiner variadic component |
+        | that is linear and a component in the middle receives optional input from other components and input from the user |
+        | that has a loop in the middle |
+        | that has variadic component that receives a conditional input |
+        | that has a string variadic component |
 
     Scenario Outline: Running a bad Pipeline
         Given a pipeline <kind>
@@ -47,3 +54,4 @@ Feature: Pipeline running
         | kind | exception |
         | that has an infinite loop | PipelineMaxComponentRuns |
         | that has a component that doesn't return a dictionary | PipelineRuntimeError |
+        | that has a cycle that would get it stuck | PipelineRuntimeError |

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -1,15 +1,24 @@
+import json
 from typing import List, Optional, Dict, Any
+import re
 
 from pytest_bdd import scenarios, given
 import pytest
 
 from haystack import Document, component
+from haystack.document_stores.types import DuplicatePolicy
 from haystack.dataclasses import ChatMessage, GeneratedAnswer
 from haystack.components.routers import ConditionalRouter
-from haystack.components.builders import PromptBuilder, AnswerBuilder
+from haystack.components.builders import PromptBuilder, AnswerBuilder, ChatPromptBuilder
+from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.components.joiners import BranchJoiner, DocumentJoiner
+from haystack.components.joiners import (
+    BranchJoiner,
+    DocumentJoiner,
+    AnswerJoiner,
+    StringJoiner,
+)
 from haystack.testing.sample_components import (
     Accumulate,
     AddFixedValue,
@@ -25,12 +34,9 @@ from haystack.testing.sample_components import (
     Hello,
     TextSplitter,
     StringListJoiner,
-    SelfLoop,
 )
 from haystack.testing.factory import component_class
-
 from haystack_experimental.core import AsyncPipeline
-
 
 from test.core.pipeline.features.conftest import PipelineRunData
 
@@ -41,7 +47,7 @@ scenarios("pipeline_run.feature")
 
 @given("a pipeline that has no components", target_fixture="pipeline_data")
 def pipeline_that_has_no_components():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     inputs = {}
     expected_outputs = {}
     return pipeline, [PipelineRunData(inputs=inputs, expected_outputs=expected_outputs)]
@@ -49,7 +55,7 @@ def pipeline_that_has_no_components():
 
 @given("a pipeline that is linear", target_fixture="pipeline_data")
 def pipeline_that_is_linear():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue())
     pipeline.add_component("double", Double())
@@ -70,20 +76,35 @@ def pipeline_that_is_linear():
 
 @given("a pipeline that has an infinite loop", target_fixture="pipeline_data")
 def pipeline_that_has_an_infinite_loop():
-    def custom_init(self):
-        component.set_input_type(self, "x", int)
-        component.set_input_type(self, "y", int, 1)
-        component.set_output_types(self, a=int, b=int)
+    routes = [
+        {
+            "condition": "{{number > 2}}",
+            "output": "{{number}}",
+            "output_name": "big_number",
+            "output_type": int,
+        },
+        {
+            "condition": "{{number <= 2}}",
+            "output": "{{number + 2}}",
+            "output_name": "small_number",
+            "output_type": int,
+        },
+    ]
 
-    FakeComponent = component_class(
-        "FakeComponent", output={"a": 1, "b": 1}, extra_fields={"__init__": custom_init}
-    )
+    main_input = BranchJoiner(int)
+    first_router = ConditionalRouter(routes=routes)
+    second_router = ConditionalRouter(routes=routes)
+
     pipe = AsyncPipeline(max_runs_per_component=1)
-    pipe.add_component("first", FakeComponent())
-    pipe.add_component("second", FakeComponent())
-    pipe.connect("first.a", "second.x")
-    pipe.connect("second.b", "first.y")
-    return pipe, [PipelineRunData({"first": {"x": 1}})]
+    pipe.add_component("main_input", main_input)
+    pipe.add_component("first_router", first_router)
+    pipe.add_component("second_router", second_router)
+
+    pipe.connect("main_input", "first_router.number")
+    pipe.connect("first_router.big_number", "second_router.number")
+    pipe.connect("second_router.big_number", "main_input")
+
+    return pipe, [PipelineRunData({"main_input": {"value": 3}})]
 
 
 @given(
@@ -164,8 +185,11 @@ def pipeline_complex():
                 },
                 expected_run_order=[
                     "greet_first",
+                    "greet_enumerator",
                     "accumulate_1",
+                    "enumerate",
                     "add_two",
+                    "add_three",
                     "parity",
                     "add_one",
                     "branch_joiner",
@@ -177,9 +201,6 @@ def pipeline_complex():
                     "branch_joiner",
                     "below_10",
                     "accumulate_2",
-                    "greet_enumerator",
-                    "enumerate",
-                    "add_three",
                     "sum",
                     "diff",
                     "greet_one_last_time",
@@ -204,7 +225,7 @@ def pipeline_that_has_a_single_component_with_a_default_input():
         def run(self, a: int, b: int = 2):
             return {"c": a + b}
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("with_defaults", WithDefault())
 
     return (
@@ -402,7 +423,7 @@ def pipeline_that_has_a_single_loop_with_two_conditional_branches():
     target_fixture="pipeline_data",
 )
 def pipeline_that_has_a_component_with_dynamic_inputs_defined_in_init():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("hello", Hello())
     pipeline.add_component(
         "fstring",
@@ -449,7 +470,7 @@ def pipeline_that_has_a_component_with_dynamic_inputs_defined_in_init():
     "a pipeline that has two branches that don't merge", target_fixture="pipeline_data"
 )
 def pipeline_that_has_two_branches_that_dont_merge():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("parity", Parity())
     pipeline.add_component("add_ten", AddFixedValue(add=10))
@@ -483,7 +504,7 @@ def pipeline_that_has_two_branches_that_dont_merge():
     target_fixture="pipeline_data",
 )
 def pipeline_that_has_three_branches_that_dont_merge():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("repeat", Repeat(outputs=["first", "second"]))
     pipeline.add_component("add_ten", AddFixedValue(add=10))
@@ -522,7 +543,7 @@ def pipeline_that_has_three_branches_that_dont_merge():
 
 @given("a pipeline that has two branches that merge", target_fixture="pipeline_data")
 def pipeline_that_has_two_branches_that_merge():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue(add=2))
     pipeline.add_component("third_addition", AddFixedValue(add=2))
@@ -556,7 +577,7 @@ def pipeline_that_has_two_branches_that_merge():
     target_fixture="pipeline_data",
 )
 def pipeline_that_has_different_combinations_of_branches_that_merge_and_do_not_merge():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("add_one", AddFixedValue())
     pipeline.add_component("parity", Parity())
     pipeline.add_component("add_ten", AddFixedValue(add=10))
@@ -668,7 +689,7 @@ def pipeline_that_has_a_component_with_mutable_input():
             input_list.append("extra_item")
             return {"mangled_list": input_list}
 
-    pipe = AsyncPipeline()
+    pipe = AsyncPipeline(max_runs_per_component=1)
     pipe.add_component("mangler1", InputMangler())
     pipe.add_component("mangler2", InputMangler())
     pipe.add_component("concat1", StringListJoiner())
@@ -726,7 +747,7 @@ def pipeline_that_has_a_component_with_mutable_output_sent_to_multiple_inputs():
     mm1 = MessageMerger()
     mm2 = MessageMerger()
 
-    pipe = AsyncPipeline()
+    pipe = AsyncPipeline(max_runs_per_component=1)
     pipe.add_component("prompt_builder", prompt_builder)
     pipe.add_component("llm", llm)
     pipe.add_component("mm1", mm1)
@@ -788,7 +809,7 @@ def pipeline_that_has_a_greedy_and_variadic_component_after_a_component_with_def
     document_store = InMemoryDocumentStore()
     document_store.write_documents([Document(content="This is a simple document")])
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     template = "Given this documents: {{ documents|join(', ', attribute='content') }} Answer this question: {{ query }}"
     pipeline.add_component(
         "retriever", InMemoryBM25Retriever(document_store=document_store)
@@ -867,7 +888,7 @@ def pipeline_that_has_components_added_in_a_different_order_from_the_order_of_ex
         "Question: {{ query }}"
     )
 
-    pipe = AsyncPipeline()
+    pipe = AsyncPipeline(max_runs_per_component=1)
 
     # The order of this addition is important for the test
     # Do not edit them.
@@ -936,7 +957,7 @@ def pipeline_that_has_a_component_with_only_default_inputs():
         "Question: {{ query }}"
     )
 
-    pipe = AsyncPipeline()
+    pipe = AsyncPipeline(max_runs_per_component=1)
 
     pipe.add_component("retriever", InMemoryBM25Retriever(document_store=doc_store))
     pipe.add_component("prompt_builder", PromptBuilder(template=template))
@@ -988,10 +1009,10 @@ def pipeline_that_has_a_component_with_only_default_inputs():
 
 
 @given(
-    "a pipeline that has a component with only default inputs as first to run",
+    "a pipeline that has a component with only default inputs as first to run and receives inputs from a loop",
     target_fixture="pipeline_data",
 )
-def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
+def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run_and_receives_inputs_from_a_loop():
     """
     This tests verifies that a Pipeline doesn't get stuck running in a loop if
     it has all the following characterics:
@@ -1044,7 +1065,7 @@ def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
         ]
     )
 
-    pipe = AsyncPipeline()
+    pipe = AsyncPipeline(max_runs_per_component=1)
 
     pipe.add_component("prompt_builder", PromptBuilder(template=template))
     pipe.add_component("generator", FakeGenerator())
@@ -1080,7 +1101,7 @@ def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
     target_fixture="pipeline_data",
 )
 def pipeline_that_has_multiple_branches_that_merge_into_a_component_with_a_single_variadic_input():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("add_one", AddFixedValue())
     pipeline.add_component("parity", Remainder(divisor=2))
     pipeline.add_component("add_ten", AddFixedValue(add=10))
@@ -1128,7 +1149,7 @@ def pipeline_that_has_multiple_branches_that_merge_into_a_component_with_a_singl
     target_fixture="pipeline_data",
 )
 def pipeline_that_has_multiple_branches_of_different_lengths_that_merge_into_a_component_with_a_single_variadic_input():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue(add=2))
     pipeline.add_component("third_addition", AddFixedValue(add=2))
@@ -1164,7 +1185,7 @@ def pipeline_that_has_multiple_branches_of_different_lengths_that_merge_into_a_c
     target_fixture="pipeline_data",
 )
 def pipeline_that_is_linear_and_returns_intermediate_outputs():
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue())
     pipeline.add_component("double", Double())
@@ -1278,7 +1299,7 @@ def pipeline_that_is_linear_and_returns_intermediate_outputs_from_multiple_socke
         def run(self, value: int):
             return {"value": value * 2, "original": value}
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue())
     pipeline.add_component("double", DoubleWithOriginal())
@@ -1332,7 +1353,7 @@ def pipeline_that_has_a_component_with_default_inputs_that_doesnt_receive_anythi
     ]
     router = ConditionalRouter(routes)
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("router", router)
     pipeline.add_component(
         "pb", PromptBuilder(template="Ok, I know, that's {{language}}")
@@ -1410,7 +1431,7 @@ def pipeline_that_has_a_component_with_default_inputs_that_doesnt_receive_anythi
     )
     fallback_llm = FakeGenerator()
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("prompt", prompt)
     pipeline.add_component("llm", llm)
     pipeline.add_component("router", router)
@@ -1529,7 +1550,7 @@ def pipeline_that_has_a_loop_and_a_component_with_default_inputs_that_doesnt_rec
     llm = FakeGenerator()
     validator = FakeOutputValidator()
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component("prompt_builder", prompt_builder)
 
     pipeline.add_component("llm", llm)
@@ -1630,7 +1651,7 @@ def pipeline_that_has_multiple_components_with_only_default_inputs_and_are_added
         def run(self, prompt: str, generation_kwargs: Optional[Dict[str, Any]] = None):
             return {"replies": ["This is a reply"], "meta": {"meta_key": "meta_value"}}
 
-    pipeline = AsyncPipeline()
+    pipeline = AsyncPipeline(max_runs_per_component=1)
     pipeline.add_component(name="retriever", instance=FakeRetriever())
     pipeline.add_component(name="ranker", instance=FakeRanker())
     pipeline.add_component(name="prompt_builder2", instance=prompt_builder2)
@@ -1763,5 +1784,828 @@ def that_is_linear_with_conditional_branching_and_multiple_joins():
                 expected_outputs={"joinerfinal": {"documents": []}},
                 expected_run_order=["router", "emptyretriever", "joinerfinal"],
             ),
+        ],
+    )
+
+
+@given("a pipeline that is a simple agent", target_fixture="pipeline_data")
+def that_is_a_simple_agent():
+    search_message_template = """
+    Given these web search results:
+
+    {% for doc in documents %}
+        {{ doc.content }}
+    {% endfor %}
+
+    Be as brief as possible, max one sentence.
+    Answer the question: {{search_query}}
+    """
+
+    react_message_template = """
+    Solve a question answering task with interleaving Thought, Action, Observation steps.
+
+    Thought reasons about the current situation
+
+    Action can be:
+    google_search - Searches Google for the exact concept/entity (given in square brackets) and returns the results for you to use
+    finish - Returns the final answer (given in square brackets) and finishes the task
+
+    Observation summarizes the Action outcome and helps in formulating the next
+    Thought in Thought, Action, Observation interleaving triplet of steps.
+
+    After each Observation, provide the next Thought and next Action.
+    Don't execute multiple steps even though you know the answer.
+    Only generate Thought and Action, never Observation, you'll get Observation from Action.
+    Follow the pattern in the example below.
+
+    Example:
+    ###########################
+    Question: Which magazine was started first Arthur’s Magazine or First for Women?
+    Thought: I need to search Arthur’s Magazine and First for Women, and find which was started
+    first.
+    Action: google_search[When was 'Arthur’s Magazine' started?]
+    Observation: Arthur’s Magazine was an American literary periodical ˘
+    published in Philadelphia and founded in 1844. Edited by Timothy Shay Arthur, it featured work by
+    Edgar A. Poe, J.H. Ingraham, Sarah Josepha Hale, Thomas G. Spear, and others. In May 1846
+    it was merged into Godey’s Lady’s Book.
+    Thought: Arthur’s Magazine was started in 1844. I need to search First for Women founding date next
+    Action: google_search[When was 'First for Women' magazine started?]
+    Observation: First for Women is a woman’s magazine published by Bauer Media Group in the
+    USA. The magazine was started in 1989. It is based in Englewood Cliffs, New Jersey. In 2011
+    the circulation of the magazine was 1,310,696 copies.
+    Thought: First for Women was started in 1989. 1844 (Arthur’s Magazine) ¡ 1989 (First for
+    Women), so Arthur’s Magazine was started first.
+    Action: finish[Arthur’s Magazine]
+    ############################
+
+    Let's start, the question is: {{query}}
+
+    Thought:
+    """
+
+    routes = [
+        {
+            "condition": "{{'search' in tool_id_and_param[0]}}",
+            "output": "{{tool_id_and_param[1]}}",
+            "output_name": "search",
+            "output_type": str,
+        },
+        {
+            "condition": "{{'finish' in tool_id_and_param[0]}}",
+            "output": "{{tool_id_and_param[1]}}",
+            "output_name": "finish",
+            "output_type": str,
+        },
+    ]
+
+    @component
+    class FakeThoughtActionOpenAIChatGenerator:
+        run_counter = 0
+
+        @component.output_types(replies=List[ChatMessage])
+        def run(
+            self,
+            messages: List[ChatMessage],
+            generation_kwargs: Optional[Dict[str, Any]] = None,
+        ):
+            if self.run_counter == 0:
+                self.run_counter += 1
+                return {
+                    "replies": [
+                        ChatMessage.from_assistant(
+                            "thinking\n Action: google_search[What is taller, Eiffel Tower or Leaning Tower of Pisa]\n"
+                        )
+                    ]
+                }
+
+            return {
+                "replies": [
+                    ChatMessage.from_assistant(
+                        "thinking\n Action: finish[Eiffel Tower]\n"
+                    )
+                ]
+            }
+
+    @component
+    class FakeConclusionOpenAIChatGenerator:
+        @component.output_types(replies=List[ChatMessage])
+        def run(
+            self,
+            messages: List[ChatMessage],
+            generation_kwargs: Optional[Dict[str, Any]] = None,
+        ):
+            return {
+                "replies": [
+                    ChatMessage.from_assistant("Tower of Pisa is 55 meters tall\n")
+                ]
+            }
+
+    @component
+    class FakeSerperDevWebSearch:
+        @component.output_types(documents=List[Document])
+        def run(self, query: str):
+            return {
+                "documents": [
+                    Document(content="Eiffel Tower is 300 meters tall"),
+                    Document(content="Tower of Pisa is 55 meters tall"),
+                ]
+            }
+
+    # main part
+    pipeline = AsyncPipeline()
+    pipeline.add_component("main_input", BranchJoiner(List[ChatMessage]))
+    pipeline.add_component("prompt_builder", ChatPromptBuilder(variables=["query"]))
+    pipeline.add_component("llm", FakeThoughtActionOpenAIChatGenerator())
+
+    @component
+    class ToolExtractor:
+        @component.output_types(output=List[str])
+        def run(self, messages: List[ChatMessage]):
+            prompt: str = messages[-1].content
+            lines = prompt.strip().split("\n")
+            for line in reversed(lines):
+                pattern = r"Action:\s*(\w+)\[(.*?)\]"
+
+                match = re.search(pattern, line)
+                if match:
+                    action_name = match.group(1)
+                    parameter = match.group(2)
+                    return {"output": [action_name, parameter]}
+            return {"output": [None, None]}
+
+    pipeline.add_component("tool_extractor", ToolExtractor())
+
+    @component
+    class PromptConcatenator:
+        def __init__(self, suffix: str = ""):
+            self._suffix = suffix
+
+        @component.output_types(output=List[ChatMessage])
+        def run(self, replies: List[ChatMessage], current_prompt: List[ChatMessage]):
+            content = current_prompt[-1].content + replies[-1].content + self._suffix
+            return {"output": [ChatMessage.from_user(content)]}
+
+    @component
+    class SearchOutputAdapter:
+        @component.output_types(output=List[ChatMessage])
+        def run(self, replies: List[ChatMessage]):
+            content = f"Observation: {replies[-1].content}\n"
+            return {"output": [ChatMessage.from_assistant(content)]}
+
+    pipeline.add_component("prompt_concatenator_after_action", PromptConcatenator())
+
+    pipeline.add_component("router", ConditionalRouter(routes))
+    pipeline.add_component("router_search", FakeSerperDevWebSearch())
+    pipeline.add_component(
+        "search_prompt_builder",
+        ChatPromptBuilder(variables=["documents", "search_query"]),
+    )
+    pipeline.add_component("search_llm", FakeConclusionOpenAIChatGenerator())
+
+    pipeline.add_component("search_output_adapter", SearchOutputAdapter())
+    pipeline.add_component(
+        "prompt_concatenator_after_observation",
+        PromptConcatenator(suffix="\nThought: "),
+    )
+
+    # main
+    pipeline.connect("main_input", "prompt_builder.template")
+    pipeline.connect("prompt_builder.prompt", "llm.messages")
+    pipeline.connect("llm.replies", "prompt_concatenator_after_action.replies")
+
+    # tools
+    pipeline.connect(
+        "prompt_builder.prompt", "prompt_concatenator_after_action.current_prompt"
+    )
+    pipeline.connect("prompt_concatenator_after_action", "tool_extractor.messages")
+
+    pipeline.connect("tool_extractor", "router")
+    pipeline.connect("router.search", "router_search.query")
+    pipeline.connect("router_search.documents", "search_prompt_builder.documents")
+    pipeline.connect("router.search", "search_prompt_builder.search_query")
+    pipeline.connect("search_prompt_builder.prompt", "search_llm.messages")
+
+    pipeline.connect("search_llm.replies", "search_output_adapter.replies")
+    pipeline.connect(
+        "search_output_adapter", "prompt_concatenator_after_observation.replies"
+    )
+    pipeline.connect(
+        "prompt_concatenator_after_action",
+        "prompt_concatenator_after_observation.current_prompt",
+    )
+    pipeline.connect("prompt_concatenator_after_observation", "main_input")
+
+    search_message = [ChatMessage.from_user(search_message_template)]
+    messages = [ChatMessage.from_user(react_message_template)]
+    question = "which tower is taller: eiffel tower or tower of pisa?"
+
+    return pipeline, [
+        PipelineRunData(
+            inputs={
+                "main_input": {"value": messages},
+                "prompt_builder": {"query": question},
+                "search_prompt_builder": {"template": search_message},
+            },
+            expected_outputs={"router": {"finish": "Eiffel Tower"}},
+            expected_run_order=[
+                "main_input",
+                "prompt_builder",
+                "llm",
+                "prompt_concatenator_after_action",
+                "tool_extractor",
+                "router",
+                "router_search",
+                "search_prompt_builder",
+                "search_llm",
+                "search_output_adapter",
+                "prompt_concatenator_after_observation",
+                "main_input",
+                "prompt_builder",
+                "llm",
+                "prompt_concatenator_after_action",
+                "tool_extractor",
+                "router",
+            ],
+        )
+    ]
+
+
+@given(
+    "a pipeline that has a variadic component that receives partial inputs",
+    target_fixture="pipeline_data",
+)
+def that_has_a_variadic_component_that_receives_partial_inputs():
+    @component
+    class ConditionalDocumentCreator:
+        def __init__(self, content: str):
+            self._content = content
+
+        @component.output_types(documents=List[Document], noop=None)
+        def run(self, create_document: bool = False):
+            if create_document:
+                return {
+                    "documents": [Document(id=self._content, content=self._content)]
+                }
+            return {"noop": None}
+
+    pipeline = AsyncPipeline(max_runs_per_component=1)
+    pipeline.add_component(
+        "first_creator", ConditionalDocumentCreator(content="First document")
+    )
+    pipeline.add_component(
+        "second_creator", ConditionalDocumentCreator(content="Second document")
+    )
+    pipeline.add_component(
+        "third_creator", ConditionalDocumentCreator(content="Third document")
+    )
+    pipeline.add_component("documents_joiner", DocumentJoiner())
+
+    pipeline.connect("first_creator.documents", "documents_joiner.documents")
+    pipeline.connect("second_creator.documents", "documents_joiner.documents")
+    pipeline.connect("third_creator.documents", "documents_joiner.documents")
+
+    return (
+        pipeline,
+        [
+            PipelineRunData(
+                inputs={
+                    "first_creator": {"create_document": True},
+                    "third_creator": {"create_document": True},
+                },
+                expected_outputs={
+                    "second_creator": {"noop": None},
+                    "documents_joiner": {
+                        "documents": [
+                            Document(id="First document", content="First document"),
+                            Document(id="Third document", content="Third document"),
+                        ]
+                    },
+                },
+                expected_run_order=[
+                    "first_creator",
+                    "second_creator",
+                    "third_creator",
+                    "documents_joiner",
+                ],
+            ),
+            PipelineRunData(
+                inputs={
+                    "first_creator": {"create_document": True},
+                    "second_creator": {"create_document": True},
+                },
+                expected_outputs={
+                    "third_creator": {"noop": None},
+                    "documents_joiner": {
+                        "documents": [
+                            Document(id="First document", content="First document"),
+                            Document(id="Second document", content="Second document"),
+                        ]
+                    },
+                },
+                expected_run_order=[
+                    "first_creator",
+                    "second_creator",
+                    "third_creator",
+                    "documents_joiner",
+                ],
+            ),
+        ],
+    )
+
+
+@given(
+    "a pipeline that has an answer joiner variadic component",
+    target_fixture="pipeline_data",
+)
+def that_has_an_answer_joiner_variadic_component():
+    query = "What's Natural Language Processing?"
+
+    pipeline = AsyncPipeline(max_runs_per_component=1)
+    pipeline.add_component("answer_builder_1", AnswerBuilder())
+    pipeline.add_component("answer_builder_2", AnswerBuilder())
+    pipeline.add_component("answer_joiner", AnswerJoiner())
+
+    pipeline.connect("answer_builder_1.answers", "answer_joiner")
+    pipeline.connect("answer_builder_2.answers", "answer_joiner")
+
+    return (
+        pipeline,
+        [
+            PipelineRunData(
+                inputs={
+                    "answer_builder_1": {
+                        "query": query,
+                        "replies": ["This is a test answer"],
+                    },
+                    "answer_builder_2": {
+                        "query": query,
+                        "replies": ["This is a second test answer"],
+                    },
+                },
+                expected_outputs={
+                    "answer_joiner": {
+                        "answers": [
+                            GeneratedAnswer(
+                                data="This is a test answer",
+                                query="What's Natural Language Processing?",
+                                documents=[],
+                                meta={},
+                            ),
+                            GeneratedAnswer(
+                                data="This is a second test answer",
+                                query="What's Natural Language Processing?",
+                                documents=[],
+                                meta={},
+                            ),
+                        ]
+                    }
+                },
+                expected_run_order=[
+                    "answer_builder_1",
+                    "answer_builder_2",
+                    "answer_joiner",
+                ],
+            )
+        ],
+    )
+
+
+@given(
+    "a pipeline that is linear and a component in the middle receives optional input from other components and input from the user",
+    target_fixture="pipeline_data",
+)
+def that_is_linear_and_a_component_in_the_middle_receives_optional_input_from_other_components_and_input_from_the_user():
+    @component
+    class QueryMetadataExtractor:
+        @component.output_types(filters=Dict[str, str])
+        def run(self, prompt: str):
+            metadata = json.loads(prompt)
+            filters = []
+            for key, value in metadata.items():
+                filters.append(
+                    {"field": f"meta.{key}", "operator": "==", "value": value}
+                )
+
+            return {"filters": {"operator": "AND", "conditions": filters}}
+
+    documents = [
+        Document(
+            content="some publication about Alzheimer prevention research done over 2023 patients study",
+            meta={"year": 2022, "disease": "Alzheimer", "author": "Michael Butter"},
+            id="doc1",
+        ),
+        Document(
+            content="some text about investigation and treatment of Alzheimer disease",
+            meta={"year": 2023, "disease": "Alzheimer", "author": "John Bread"},
+            id="doc2",
+        ),
+        Document(
+            content="A study on the effectiveness of new therapies for Parkinson's disease",
+            meta={"year": 2022, "disease": "Parkinson", "author": "Alice Smith"},
+            id="doc3",
+        ),
+        Document(
+            content="An overview of the latest research on the genetics of Parkinson's disease and its implications for treatment",
+            meta={"year": 2023, "disease": "Parkinson", "author": "David Jones"},
+            id="doc4",
+        ),
+    ]
+    document_store = InMemoryDocumentStore(bm25_algorithm="BM25Plus")
+    document_store.write_documents(
+        documents=documents, policy=DuplicatePolicy.OVERWRITE
+    )
+
+    pipeline = AsyncPipeline()
+    pipeline.add_component(
+        instance=PromptBuilder('{"disease": "Alzheimer", "year": 2023}'), name="builder"
+    )
+    pipeline.add_component(instance=QueryMetadataExtractor(), name="metadata_extractor")
+    pipeline.add_component(
+        instance=InMemoryBM25Retriever(document_store=document_store), name="retriever"
+    )
+    pipeline.add_component(instance=DocumentJoiner(), name="document_joiner")
+
+    pipeline.connect("builder.prompt", "metadata_extractor.prompt")
+    pipeline.connect("metadata_extractor.filters", "retriever.filters")
+    pipeline.connect("retriever.documents", "document_joiner.documents")
+
+    query = "publications 2023 Alzheimer's disease"
+
+    return (
+        pipeline,
+        [
+            PipelineRunData(
+                inputs={"retriever": {"query": query}},
+                expected_outputs={
+                    "document_joiner": {
+                        "documents": [
+                            Document(
+                                content="some text about investigation and treatment of Alzheimer disease",
+                                meta={
+                                    "year": 2023,
+                                    "disease": "Alzheimer",
+                                    "author": "John Bread",
+                                },
+                                id="doc2",
+                                score=3.324112496100923,
+                            )
+                        ]
+                    }
+                },
+                expected_run_order=[
+                    "builder",
+                    "metadata_extractor",
+                    "retriever",
+                    "document_joiner",
+                ],
+            )
+        ],
+    )
+
+
+@given(
+    "a pipeline that has a cycle that would get it stuck",
+    target_fixture="pipeline_data",
+)
+def that_has_a_cycle_that_would_get_it_stuck():
+    template = """
+    You are an experienced and accurate Turkish CX speacialist that classifies customer comments into pre-defined categories below:\n
+    Negative experience labels:
+    - Late delivery
+    - Rotten/spoilt item
+    - Bad Courier behavior
+
+    Positive experience labels:
+    - Good courier behavior
+    - Thanks & appreciation
+    - Love message to courier
+    - Fast delivery
+    - Quality of products
+
+    Create a JSON object as a response. The fields are: 'positive_experience', 'negative_experience'.
+    Assign at least one of the pre-defined labels to the given customer comment under positive and negative experience fields.
+    If the comment has a positive experience, list the label under 'positive_experience' field.
+    If the comments has a negative_experience, list it under the 'negative_experience' field.
+    Here is the comment:\n{{ comment }}\n. Just return the category names in the list. If there aren't any, return an empty list.
+
+    {% if invalid_replies and error_message %}
+    You already created the following output in a previous attempt: {{ invalid_replies }}
+    However, this doesn't comply with the format requirements from above and triggered this Python exception: {{ error_message }}
+    Correct the output and try again. Just return the corrected output without any extra explanations.
+    {% endif %}
+    """
+    prompt_builder = PromptBuilder(
+        template=template,
+        required_variables=["comment", "invalid_replies", "error_message"],
+    )
+
+    @component
+    class FakeOutputValidator:
+        @component.output_types(
+            valid_replies=List[str],
+            invalid_replies=Optional[List[str]],
+            error_message=Optional[str],
+        )
+        def run(self, replies: List[str]):
+            if not getattr(self, "called", False):
+                self.called = True
+                return {
+                    "invalid_replies": ["This is an invalid reply"],
+                    "error_message": "this is an error message",
+                }
+            return {"valid_replies": replies}
+
+    @component
+    class FakeGenerator:
+        @component.output_types(replies=List[str])
+        def run(self, prompt: str):
+            return {"replies": ["This is a valid reply"]}
+
+    llm = FakeGenerator()
+    validator = FakeOutputValidator()
+
+    pipeline = AsyncPipeline(max_runs_per_component=1)
+    pipeline.add_component("prompt_builder", prompt_builder)
+
+    pipeline.add_component("llm", llm)
+    pipeline.add_component("output_validator", validator)
+
+    pipeline.connect("prompt_builder.prompt", "llm.prompt")
+    pipeline.connect("llm.replies", "output_validator.replies")
+    pipeline.connect(
+        "output_validator.invalid_replies", "prompt_builder.invalid_replies"
+    )
+
+    pipeline.connect("output_validator.error_message", "prompt_builder.error_message")
+
+    comment = "I loved the quality of the meal but the courier was rude"
+    return (
+        pipeline,
+        [PipelineRunData(inputs={"prompt_builder": {"comment": comment}})],
+    )
+
+
+@given("a pipeline that has a loop in the middle", target_fixture="pipeline_data")
+def that_has_a_loop_in_the_middle():
+    @component
+    class FakeGenerator:
+        @component.output_types(replies=List[str])
+        def run(self, prompt: str):
+            replies = []
+            if getattr(self, "first_run", True):
+                self.first_run = False
+                replies.append("No answer")
+            else:
+                replies.append("42")
+            return {"replies": replies}
+
+    @component
+    class PromptCleaner:
+        @component.output_types(clean_prompt=str)
+        def run(self, prompt: str):
+            return {"clean_prompt": prompt.strip()}
+
+    routes = [
+        {
+            "condition": "{{ 'No answer' in replies }}",
+            "output": "{{ replies }}",
+            "output_name": "invalid_replies",
+            "output_type": List[str],
+        },
+        {
+            "condition": "{{ 'No answer' not in replies }}",
+            "output": "{{ replies }}",
+            "output_name": "valid_replies",
+            "output_type": List[str],
+        },
+    ]
+
+    pipeline = AsyncPipeline(max_runs_per_component=20)
+    pipeline.add_component("prompt_cleaner", PromptCleaner())
+    pipeline.add_component(
+        "prompt_builder",
+        PromptBuilder(template="", variables=["question", "invalid_replies"]),
+    )
+    pipeline.add_component("llm", FakeGenerator())
+    pipeline.add_component("answer_validator", ConditionalRouter(routes=routes))
+    pipeline.add_component("answer_builder", AnswerBuilder())
+
+    pipeline.connect("prompt_cleaner.clean_prompt", "prompt_builder.template")
+    pipeline.connect("prompt_builder.prompt", "llm.prompt")
+    pipeline.connect("llm.replies", "answer_validator.replies")
+    pipeline.connect(
+        "answer_validator.invalid_replies", "prompt_builder.invalid_replies"
+    )
+    pipeline.connect("answer_validator.valid_replies", "answer_builder.replies")
+
+    question = "What is the answer?"
+    return (
+        pipeline,
+        [
+            PipelineRunData(
+                inputs={
+                    "prompt_cleaner": {"prompt": "Random template"},
+                    "prompt_builder": {"question": question},
+                    "answer_builder": {"query": question},
+                },
+                expected_outputs={
+                    "answer_builder": {
+                        "answers": [
+                            GeneratedAnswer(data="42", query=question, documents=[])
+                        ]
+                    }
+                },
+                expected_run_order=[
+                    "prompt_cleaner",
+                    "prompt_builder",
+                    "llm",
+                    "answer_validator",
+                    "prompt_builder",
+                    "llm",
+                    "answer_validator",
+                    "answer_builder",
+                ],
+            )
+        ],
+    )
+
+
+@given(
+    "a pipeline that has variadic component that receives a conditional input",
+    target_fixture="pipeline_data",
+)
+def that_has_variadic_component_that_receives_a_conditional_input():
+    pipe = AsyncPipeline(max_runs_per_component=1)
+    routes = [
+        {
+            "condition": "{{ documents|length > 1 }}",
+            "output": "{{ documents }}",
+            "output_name": "long",
+            "output_type": List[Document],
+        },
+        {
+            "condition": "{{ documents|length <= 1 }}",
+            "output": "{{ documents }}",
+            "output_name": "short",
+            "output_type": List[Document],
+        },
+    ]
+
+    @component
+    class NoOp:
+        @component.output_types(documents=List[Document])
+        def run(self, documents: List[Document]):
+            return {"documents": documents}
+
+    @component
+    class CommaSplitter:
+        @component.output_types(documents=List[Document])
+        def run(self, documents: List[Document]):
+            res = []
+            current_id = 0
+            for doc in documents:
+                for split in doc.content.split(","):
+                    res.append(Document(content=split, id=str(current_id)))
+                    current_id += 1
+            return {"documents": res}
+
+    pipe.add_component("conditional_router", ConditionalRouter(routes, unsafe=True))
+    pipe.add_component(
+        "empty_lines_cleaner",
+        DocumentCleaner(
+            remove_empty_lines=True, remove_extra_whitespaces=False, keep_id=True
+        ),
+    )
+    pipe.add_component("comma_splitter", CommaSplitter())
+    pipe.add_component("document_cleaner", DocumentCleaner(keep_id=True))
+    pipe.add_component("document_joiner", DocumentJoiner())
+
+    pipe.add_component("noop2", NoOp())
+    pipe.add_component("noop3", NoOp())
+
+    pipe.connect("noop2", "noop3")
+    pipe.connect("noop3", "conditional_router")
+
+    pipe.connect("conditional_router.long", "empty_lines_cleaner")
+    pipe.connect("empty_lines_cleaner", "document_joiner")
+
+    pipe.connect("comma_splitter", "document_cleaner")
+    pipe.connect("document_cleaner", "document_joiner")
+    pipe.connect("comma_splitter", "document_joiner")
+
+    document = Document(
+        id="1000",
+        content="This document has so many, sentences. Like this one, or this one. Or even this other one.",
+    )
+
+    return pipe, [
+        PipelineRunData(
+            inputs={
+                "noop2": {"documents": [document]},
+                "comma_splitter": {"documents": [document]},
+            },
+            expected_outputs={
+                "conditional_router": {
+                    "short": [
+                        Document(
+                            id="1000",
+                            content="This document has so many, sentences. Like this one, or this one. Or even this other one.",
+                        )
+                    ]
+                },
+                "document_joiner": {
+                    "documents": [
+                        Document(id="0", content="This document has so many"),
+                        Document(id="1", content=" sentences. Like this one"),
+                        Document(
+                            id="2", content=" or this one. Or even this other one."
+                        ),
+                    ]
+                },
+            },
+            expected_run_order=[
+                "comma_splitter",
+                "noop2",
+                "document_cleaner",
+                "noop3",
+                "conditional_router",
+                "document_joiner",
+            ],
+        ),
+        PipelineRunData(
+            inputs={
+                "noop2": {"documents": [document, document]},
+                "comma_splitter": {"documents": [document, document]},
+            },
+            expected_outputs={
+                "document_joiner": {
+                    "documents": [
+                        Document(id="0", content="This document has so many"),
+                        Document(id="1", content=" sentences. Like this one"),
+                        Document(
+                            id="2", content=" or this one. Or even this other one."
+                        ),
+                        Document(id="3", content="This document has so many"),
+                        Document(id="4", content=" sentences. Like this one"),
+                        Document(
+                            id="5", content=" or this one. Or even this other one."
+                        ),
+                        Document(
+                            id="1000",
+                            content="This document has so many, sentences. Like this one, or this one. Or even this other one.",
+                        ),
+                    ]
+                }
+            },
+            expected_run_order=[
+                "comma_splitter",
+                "noop2",
+                "document_cleaner",
+                "noop3",
+                "conditional_router",
+                "empty_lines_cleaner",
+                "document_joiner",
+            ],
+        ),
+    ]
+
+
+@given(
+    "a pipeline that has a string variadic component", target_fixture="pipeline_data"
+)
+def that_has_a_string_variadic_component():
+    string_1 = "What's Natural Language Processing?"
+    string_2 = "What's is life?"
+
+    pipeline = AsyncPipeline()
+    pipeline.add_component("prompt_builder_1", PromptBuilder("Builder 1: {{query}}"))
+    pipeline.add_component("prompt_builder_2", PromptBuilder("Builder 2: {{query}}"))
+    pipeline.add_component("string_joiner", StringJoiner())
+
+    pipeline.connect("prompt_builder_1.prompt", "string_joiner.strings")
+    pipeline.connect("prompt_builder_2.prompt", "string_joiner.strings")
+
+    return (
+        pipeline,
+        [
+            PipelineRunData(
+                inputs={
+                    "prompt_builder_1": {"query": string_1},
+                    "prompt_builder_2": {"query": string_2},
+                },
+                expected_outputs={
+                    "string_joiner": {
+                        "strings": [
+                            "Builder 1: What's Natural Language Processing?",
+                            "Builder 2: What's is life?",
+                        ]
+                    }
+                },
+                expected_run_order=[
+                    "prompt_builder_1",
+                    "prompt_builder_2",
+                    "string_joiner",
+                ],
+            )
         ],
     )


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Port the recent changes to the pipeline run logic into `AsyncPipeline`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
The primary changes to the existing code:
- `_run_component` calls the `run_async` method of the component if it exists. If not, launch the `run` method on an executor in the current event loop.
- `includes_outputs_from` is removed as pipeline's run method returns an async iterator. The old behaviour can be reproduced with the new `run_async_pipeline` helper function.
- `_run_subgraph` yields the output of each component greedily.

The test are copied from the core package. The lints might fail, but they will be fixed when the `async-experiments` branch is merged into `main`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
