### PR TITLE
Disable `ensure_ascii` when dumping to json tool responses

### DIFF
--- a/haystack_experimental/components/generators/chat/openai.py
+++ b/haystack_experimental/components/generators/chat/openai.py
@@ -55,7 +55,8 @@ def _convert_message_to_openai_format(message: ChatMessage) -> Dict[str, Any]:
                 {
                     "id": tc.id,
                     "type": "function",
-                    "function": {"name": tc.tool_name, "arguments": json.dumps(tc.arguments)},
+                    # We disable ensure_ascii so special chars like emojis are not converted
+                    "function": {"name": tc.tool_name, "arguments": json.dumps(tc.arguments, ensure_ascii=False)},
                 }
             )
         openai_msg["tool_calls"] = openai_tool_calls

--- a/haystack_experimental/components/tools/openai/function_caller.py
+++ b/haystack_experimental/components/tools/openai/function_caller.py
@@ -87,8 +87,9 @@ class OpenAIFunctionCaller:
                     try:
                         function_response = function_to_call(**function_args)
                         messages.append(
+                            # We disable ensure_ascii so special chars like emojis are not converted
                             ChatMessage.from_function(
-                                content=json.dumps(function_response),
+                                content=json.dumps(function_response, ensure_ascii=False),
                                 name=function_name,
                             )
                         )

--- a/haystack_experimental/components/tools/openapi/openapi_tool.py
+++ b/haystack_experimental/components/tools/openapi/openapi_tool.py
@@ -172,7 +172,8 @@ class OpenAPITool:
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error("Error invoking OpenAPI endpoint. Error: {e}", e=str(e))
             service_response = {"error": str(e)}
-        response_messages = [ChatMessage.from_user(json.dumps(service_response))]
+        # We disable ensure_ascii so special chars like emojis are not converted
+        response_messages = [ChatMessage.from_user(json.dumps(service_response, ensure_ascii=False))]
 
         return {"service_response": response_messages}
 

--- a/haystack_experimental/components/tools/tool_invoker.py
+++ b/haystack_experimental/components/tools/tool_invoker.py
@@ -145,7 +145,8 @@ class ToolInvoker:
 
         if self.convert_result_to_json_string:
             try:
-                tool_result_str = json.dumps(result)
+                # We disable ensure_ascii so special chars like emojis are not converted
+                tool_result_str = json.dumps(result, ensure_ascii=False)
             except Exception as e:
                 if self.raise_on_failure:
                     raise StringConversionError("Failed to convert tool result to string using `json.dumps`") from e


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack#8170

### Proposed Changes:

Set `ensure_ascii=False` when dumping to JSON tool or function calls, this way special chars like emojis are not lost.

### How did you test it?

I tested manually.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
