### PR TITLE
Add missing parent span when running cycle in async Pipeline

### DIFF
--- a/haystack_experimental/core/pipeline/async_pipeline.py
+++ b/haystack_experimental/core/pipeline/async_pipeline.py
@@ -145,6 +145,8 @@ class AsyncPipeline(PipelineBase):
         cycle: List[str],
         component_name: str,
         components_inputs: Dict[str, Dict[str, Any]],
+        *,
+        parent_span: Optional[tracing.Span] = None,
     ) -> AsyncIterator[Tuple[Dict[str, Any], bool]]:
         """
         Runs a `cycle` in the Pipeline starting from `component_name`.
@@ -441,7 +443,7 @@ class AsyncPipeline(PipelineBase):
                     # are run doesn't make a different whether we pick the first or any of the others a
                     # Component is part of.
                     async for subgraph_output, is_final_output in self._run_subgraph(
-                        cycles[0], name, components_inputs
+                        cycles[0], name, components_inputs, parent_span=span
                     ):
                         if not is_final_output:
                             yield subgraph_output


### PR DESCRIPTION
### Related Issues

Related to PR deepset-ai/haystack#8576

### Proposed Changes:

Add missing `parent_span` when running cycles in a Pipeline.

### How did you test it?

I tested the functionality from the original PR, given that the code is basically identical this should work too.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
