### PR TITLE
feat: Update handling of tools_strict to ensure compatibility with vLLM

### DIFF
--- a/haystack_experimental/components/generators/chat/openai.py
+++ b/haystack_experimental/components/generators/chat/openai.py
@@ -447,7 +447,10 @@ class OpenAIChatGenerator:
             openai_tools = [
                 {
                     "type": "function",
-                    "function": {**t.tool_spec, "strict": tools_strict},
+                    "function": {
+                        **t.tool_spec,
+                        **({"strict": tools_strict} if tools_strict else {}),
+                    },
                 }
                 for t in tools
             ]

--- a/haystack_experimental/components/generators/chat/openai.py
+++ b/haystack_experimental/components/generators/chat/openai.py
@@ -449,7 +449,7 @@ class OpenAIChatGenerator:
                     "type": "function",
                     "function": {
                         **t.tool_spec,
-                        **({"strict": tools_strict} if tools_strict else {}),
+                        **({"strict": tools_strict} if tools_strict is not None else {}),
                     },
                 }
                 for t in tools


### PR DESCRIPTION
### Proposed Changes:
Only add the "strict" dictionary to the openai_tools for generation, if tools_strict is available.

This ensures compatibility with vLLM (which adopts the OpenAI Interface). vLLM throws an error, if the "strict" dictionary is part of the tools list:

`openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "[{'type': 'extra_forbidden', 'loc': ('body', 'tools', 0, 'function', 'strict'), 'msg': 'Extra inputs are not permitted', 'input': False}`

### How did you test it?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue