### PR TITLE
Hierarchical doc builder doc splitter warm up

### DIFF
--- a/haystack_experimental/components/extractors/llm_metadata_extractor.py
+++ b/haystack_experimental/components/extractors/llm_metadata_extractor.py
@@ -85,7 +85,7 @@ class LLMMetadataExtractor:
     1. Identify all entities. For each identified entity, extract the following information:
     - entity_name: Name of the entity, capitalized
     - entity_type: One of the following types: [organization, product, service, industry]
-    Format each entity as {"entity": <entity_name>, "entity_type": <entity_type>}
+    Format each entity as a JSON like: {"entity": <entity_name>, "entity_type": <entity_type>}
 
     2. Return output in a single list with all the entities identified in steps 1.
 

--- a/haystack_experimental/components/splitters/hierarchical_doc_splitter.py
+++ b/haystack_experimental/components/splitters/hierarchical_doc_splitter.py
@@ -72,6 +72,8 @@ class HierarchicalDocumentSplitter:
             self.splitters[block_size] = DocumentSplitter(
                 split_length=block_size, split_overlap=self.split_overlap, split_by=self.split_by
             )
+            self.splitters[block_size].warm_up()
+
 
     @staticmethod
     def _add_meta_data(document: Document):


### PR DESCRIPTION
### Proposed Changes:

- Unless the string `json` is specific in the promo OpenAI complains about the format output to JSON, even if specific in the `"response_format": {"type": "json_object"}` parameters.
 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
