### PR TITLE
chore: make pylint rules consistent with Haystack core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,18 @@ disable = [
   "too-many-instance-attributes", # sometimes we need to have a class with more than 7 attributes
 ]
 
+[tool.pylint.'DESIGN']
+max-args = 38           # Default is 5
+max-attributes = 28     # Default is 7
+max-branches = 34       # Default is 12
+max-locals = 45         # Default is 15
+max-module-lines = 2468 # Default is 1000
+max-nested-blocks = 9   # Default is 5
+max-statements = 206    # Default is 50
+
+[tool.pylint.'SIMILARITIES']
+min-similarity-lines = 6
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--strict-markers"
@@ -227,6 +239,14 @@ ignore = [
   "SIM118",  # in-dict-keys
   "PLR0913", # too-many-arguments
 ]
+
+[tool.ruff.lint.pylint]
+allow-magic-value-types = ["float", "int", "str"]
+max-args = 14                                     # Default is 5
+max-branches = 21                                 # Default is 12
+max-public-methods = 20                           # Default is 20
+max-returns = 7                                   # Default is 6
+max-statements = 60                               # Default is 50
 
 [tool.ruff.lint.mccabe]
 max-complexity = 28


### PR DESCRIPTION
### Related Issues

- related PR https://github.com/deepset-ai/haystack-experimental/pull/171 had failures that didn't occur in Haystack core: https://github.com/deepset-ai/haystack-experimental/actions/runs/12871671575/job/35885456412

### Proposed Changes:

- add pylint rules in the same way as they are in Haystack core here: https://github.com/deepset-ai/haystack/blob/main/pyproject.toml#L243

### How did you test it?

-

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
