### PR TITLE
splitters need to be warmed up

### DIFF
--- a/haystack_experimental/components/splitters/hierarchical_doc_splitter.py
+++ b/haystack_experimental/components/splitters/hierarchical_doc_splitter.py
@@ -72,6 +72,7 @@ class HierarchicalDocumentSplitter:
             self.splitters[block_size] = DocumentSplitter(
                 split_length=block_size, split_overlap=self.split_overlap, split_by=self.split_by
             )
+            self.splitters[block_size].warm_up()
 
     @staticmethod
     def _add_meta_data(document: Document):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ extra-dependencies = [
   # LLMMetadataExtractor dependencies
   "amazon-bedrock-haystack>=1.1.1",
   "google-vertex-haystack>=2.0.0",
+  # HierachicalSplitter w/ split_by="sentence"
+  "nltk"
 ]
 
 [tool.hatch.envs.test.scripts]

--- a/test/components/splitters/test_hierarchical_doc_splitter.py
+++ b/test/components/splitters/test_hierarchical_doc_splitter.py
@@ -214,7 +214,7 @@ class TestHierarchicalDocumentSplitter:
         new_pipeline = Pipeline.from_dict(pipeline_dict)
         assert new_pipeline == pipeline
 
-    def test_slit_by_sentence_assure_warm_up_was_called(self):
+    def test_split_by_sentence_assure_warm_up_was_called(self):
         pipeline = Pipeline()
         hierarchical_doc_builder = HierarchicalDocumentSplitter(
             block_sizes={10, 5, 2}, split_overlap=0, split_by="sentence"

--- a/test/components/splitters/test_hierarchical_doc_splitter.py
+++ b/test/components/splitters/test_hierarchical_doc_splitter.py
@@ -213,3 +213,24 @@ class TestHierarchicalDocumentSplitter:
 
         new_pipeline = Pipeline.from_dict(pipeline_dict)
         assert new_pipeline == pipeline
+
+    def test_slit_by_sentence_assure_warm_up_was_called(self):
+        pipeline = Pipeline()
+        hierarchical_doc_builder = HierarchicalDocumentSplitter(
+            block_sizes={10, 5, 2}, split_overlap=0, split_by="sentence"
+        )
+        doc_store = InMemoryDocumentStore()
+        doc_writer = DocumentWriter(document_store=doc_store)
+
+        pipeline.add_component(
+            name="hierarchical_doc_splitter", instance=hierarchical_doc_builder
+        )
+        pipeline.add_component(name="doc_writer", instance=doc_writer)
+        pipeline.connect("hierarchical_doc_splitter.documents", "doc_writer")
+
+        text = "This is one sentence. This is another sentence. This is the third sentence."
+        doc = Document(content=text)
+        docs = pipeline.run({"hierarchical_doc_splitter": {"documents": [doc]}})
+
+        assert docs["doc_writer"]["documents_written"] == 3
+        assert len(doc_store.storage.values()) == 3


### PR DESCRIPTION
### Proposed Changes:

- The `HierarchicalDocumentSplitter` relies on the `DocumentSplitter` to build different hierarchy levels. The DocumentSplitter now needs to be warmup if it's meant to `split_by="sentence"`. Therefore in the `HierarchicalDocumentSplitter`is configured to `split_by="sentence"` needs to call the `.warm_up()` on all the different splitters for each level.



### How did you test it?

- manual verification  + CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
