### PR TITLE
fix: Fix license header text due to breaking changes in hawkeye

### DIFF
--- a/license-header.txt
+++ b/license-header.txt
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: ${inceptionYear}-present ${copyrightOwner}
+SPDX-FileCopyrightText: {{ props["inceptionYear"] }}-present {{ props["copyrightOwner"] }}
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Related Issues

Same issue fixed as in main Haystack library https://github.com/deepset-ai/haystack/pull/8778 (more context there)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
