### PR TITLE
refactor: changing `LLMMetadaExtractor` to use chat generators

### DIFF
--- a/haystack_experimental/components/extractors/llm_metadata_extractor.py
+++ b/haystack_experimental/components/extractors/llm_metadata_extractor.py
@@ -209,7 +209,9 @@ class LLMMetadataExtractor:
     def _init_generator(
         generator_api: LLMProvider,
         generator_api_params: Optional[Dict[str, Any]]
-    ) -> Union[OpenAIChatGenerator, AzureOpenAIChatGenerator, "AmazonBedrockChatGenerator", "VertexAIGeminiChatGenerator"]:
+    ) -> Union[
+        OpenAIChatGenerator, AzureOpenAIChatGenerator, "AmazonBedrockChatGenerator", "VertexAIGeminiChatGenerator"
+    ]:
         """
         Initialize the chat generator based on the specified API provider and parameters.
         """

--- a/haystack_experimental/components/extractors/llm_metadata_extractor.py
+++ b/haystack_experimental/components/extractors/llm_metadata_extractor.py
@@ -15,7 +15,6 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack.dataclasses import ChatMessage
 from haystack.lazy_imports import LazyImport
 from haystack.utils import deserialize_callable, deserialize_secrets_inplace
-
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
 
@@ -194,7 +193,6 @@ class LLMMetadataExtractor:
                 f"Prompt must have exactly one variable called 'document'. Found {','.join(variables)} in the prompt."
             )
         self.builder = PromptBuilder(prompt, required_variables=variables)
-
         self.raise_on_failure = raise_on_failure
         self.expected_keys = expected_keys or []
         self.generator_api = generator_api if isinstance(generator_api, LLMProvider) \
@@ -322,7 +320,7 @@ class LLMMetadataExtractor:
         self,
         documents: List[Document],
         expanded_range: Optional[List[int]] = None
-    ) -> List[Union[str, None]]:
+    ) -> List[Union[ChatMessage, None]]:
         all_prompts: List[Union[ChatMessage, None]] = []
         for document in documents:
             if not document.content:
@@ -350,7 +348,7 @@ class LLMMetadataExtractor:
              )
 
             # build a ChatMessage with the prompt
-            message = ChatMessage.from_user(prompt_with_doc['prompt'])
+            message = ChatMessage.from_user(prompt_with_doc["prompt"])
             all_prompts.append(message)
 
         return all_prompts


### PR DESCRIPTION
### Related Issues

- partially part of [#8785](https://github.com/deepset-ai/haystack/issues/8785) - changing `LLMMetadaExtractor` to use ChatGenerators

### How did you test it?

- local unit tests + manual verification + CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
