### PR TITLE
docs: add Supercomponent pydoc, delete outdated

### DIFF
--- a/docs/pydoc/config/document_stores_api.yml
+++ b/docs/pydoc/config/document_stores_api.yml
@@ -22,7 +22,7 @@ renderer:
   category_slug: experiments-api
   title: Document Stores
   slug: experimental-document-stores-api
-  order: 160
+  order: 10
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/evaluation_harness_api.yml
+++ b/docs/pydoc/config/evaluation_harness_api.yml
@@ -19,7 +19,7 @@ renderer:
   category_slug: experiments-api
   title: Evaluation Harness
   slug: experimental-evaluation-harness-api
-  order: 40
+  order: 20
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/generators_api.yml
+++ b/docs/pydoc/config/generators_api.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: experiments-api
   title: Generators
   slug: experimental-generators-api
-  order: 60
+  order: 30
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/retrievers_api.yml
+++ b/docs/pydoc/config/retrievers_api.yml
@@ -25,7 +25,7 @@ renderer:
   category_slug: experiments-api
   title: Retrievers
   slug: experimental-retrievers-api
-  order: 80
+  order: 40
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/splitters_api.yml
+++ b/docs/pydoc/config/splitters_api.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: experiments-api
   title: Splitters
   slug: experimental-splitters-api
-  order: 100
+  order: 50
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/supercomponent_api.yml
+++ b/docs/pydoc/config/supercomponent_api.yml
@@ -20,7 +20,7 @@ renderer:
   category_slug: experiments-api
   title: SuperComponent
   slug: experimental-supercomponent-api
-  order: 70
+  order: 60
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/writers_api.yml
+++ b/docs/pydoc/config/writers_api.yml
@@ -21,7 +21,7 @@ renderer:
   category_slug: experiments-api
   title: Writers
   slug: experimental-writers-api
-  order: 140
+  order: 60
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/config/writers_api.yml
+++ b/docs/pydoc/config/writers_api.yml
@@ -21,7 +21,7 @@ renderer:
   category_slug: experiments-api
   title: Writers
   slug: experimental-writers-api
-  order: 60
+  order: 70
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/docs/pydoc/supercomponent_api.yml
+++ b/docs/pydoc/supercomponent_api.yml
@@ -1,7 +1,10 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../]
-    modules: ["haystack_experimental.components.extractors.llm_metadata_extractor"]
+    modules:
+      [
+        "haystack_experimental.core.super_component.super_component"
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -13,15 +16,15 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
-  excerpt: Extracting information from documents.
+  excerpt: A class for creating super components that wrap around a pipeline.
   category_slug: experiments-api
-  title: Extractors
-  slug: experimental-generators-api
-  order: 50
+  title: SuperComponent
+  slug: experimental-supercomponent-api
+  order: 70
   markdown:
     descriptive_class_title: false
     classdef_code_block: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: experimental_extractors.md
+    filename: experimental_supercomponent_api.md


### PR DESCRIPTION
### Related Issues

- fixes #191 

### Proposed Changes:

- Add SuperComponent pydoc
- Delete outdated experiment pydoc
- Rearrange the order

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
