### PR TITLE
build: sort version numbers by major, minor instead of alphabetic

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -23,6 +23,7 @@ jobs:
         id: version_finder
         run: |
           curl -s "https://dash.readme.com/api/v1/version" --header "authorization: Basic ${{ secrets.README_API_KEY }}" > out
+          # Ensure proper semantic version sorting (2.2.0 comes before 2.10.0)
           VERSIONS=$(jq -c '[ .[] | select(.version | startswith("2.")) | { version: .version, major: (.version | split(".")[0] | tonumber), minor: (.version | split(".")[1] // "0" | gsub("[^0-9]"; "") | tonumber) } ] | sort_by(.major, .minor) | map(.version) | .[-${{ env.SYNC_LAST_N_HAYSTACK_VERSIONS }}:]' out)
           {
             echo 'versions<<EOF'

--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -23,7 +23,7 @@ jobs:
         id: version_finder
         run: |
           curl -s "https://dash.readme.com/api/v1/version" --header "authorization: Basic ${{ secrets.README_API_KEY }}" > out
-          VERSIONS=$(jq -c '[ .[] | select(.version | startswith("2.")) | .version ] | .[-${{ env.SYNC_LAST_N_HAYSTACK_VERSIONS }}:]' out)
+          VERSIONS=$(jq -c '[ .[] | select(.version | startswith("2.")) | { version: .version, major: (.version | split(".")[0] | tonumber), minor: (.version | split(".")[1] // "0" | gsub("[^0-9]"; "") | tonumber) } ] | sort_by(.major, .minor) | map(.version) | .[-${{ env.SYNC_LAST_N_HAYSTACK_VERSIONS }}:]' out)
           {
             echo 'versions<<EOF'
             echo "$VERSIONS"


### PR DESCRIPTION
### Related Issues

- @dfokina found out that the workflow syncing api docs to readme didn't run as expected. Instead of syncing to verion "2.11-unstable" it synced to "2.9" https://github.com/deepset-ai/haystack-experimental/actions/runs/13563536516/job/37911422196?pr=210

That's because this command in the workflow returns
https://github.com/deepset-ai/haystack-experimental/blob/a04539623a7d6194efd64e8cba9ca71eb19924a3/.github/workflows/api_docs.yml#L25
and the command right after return version numbers in alphabetical order instead of sorted by major.minor version
`["2.0","2.1","2.10","2.11-unstable","2.2","2.3","2.4","2.5","2.6","2.7","2.8","2.9"]`

### Proposed Changes:

- Sort versions returned by readme by major and minor version before filtering the top SYNC_LAST_N_HAYSTACK_VERSIONS.

### How did you test it?

Ran parts of the workflow locally:
```bash
curl -s "https://dash.readme.com/api/v1/version" --header "authorization: Basic TOKEN_FROM_BITWARDEN
```
gives the response from readme and I stored it locally in a file called `out`.
You can then run the current, wrong command:
```bash
jq -c '[ .[] | select(.version | startswith("2.")) | .version ] | .[-1:]' out
```
and compare to the fixed, new command
```bash
jq -c '[ .[] | select(.version | startswith("2.")) | { version: .version, major: (.version | split(".")[0] | tonumber), minor: (.version | split(".")[1] // "0" | gsub("[^0-9]"; "") | tonumber) } ] | sort_by(.major, .minor) | map(.version) | .[-1:]' out
```

### Notes for the reviewer

I suggest you run the above commands locally to test the new command and compare to the old one.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
