### PR TITLE
chore: removing wrong links for discontinued experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ that includes it. Once it reaches the end of its lifespan, the experiment will b
 
 ### Discontinued experiments
 
-| Name                        | Type                       | Final release | Cookbook                                                                                                                                 |
-| --------------------------- | -------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| [`OpenAIFunctionCaller`][2] | Function Calling Component | 0.3.0         | None                                                                                                                                     |
-| [`OpenAPITool`][3]          | OpenAPITool component      | 0.3.0         | [Notebook](https://github.com/deepset-ai/haystack-experimental/blob/fe20b69b31243f8a3976e4661d9aa8c88a2847d2/examples/openapitool.ipynb) |
+| Name                     | Type                       | Final release | Cookbook                                                                                                                                 |
+|--------------------------| -------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `OpenAIFunctionCaller`   | Function Calling Component | 0.3.0         | None                                                                                                                                     |
+| `OpenAPITool`            | OpenAPITool component      | 0.3.0         | [Notebook](https://github.com/deepset-ai/haystack-experimental/blob/fe20b69b31243f8a3976e4661d9aa8c88a2847d2/examples/openapitool.ipynb) |
 
 ## Usage
 


### PR DESCRIPTION
### Proposed Changes:

- removing dead/wrong links in the discontinued experiments section

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
