### PR TITLE
fix: Jinja2-based ComponentTools in pipelines properly handle deepcopy

### DIFF
--- a/haystack_experimental/tools/component_tool.py
+++ b/haystack_experimental/tools/component_tool.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import copy, deepcopy
 from dataclasses import fields, is_dataclass
 from inspect import getdoc
 from typing import Any, Callable, Dict, Optional, Union, get_args, get_origin
@@ -392,3 +393,29 @@ class ComponentTool(Tool):
             schema["default"] = default
 
         return schema
+
+    def __deepcopy__(self, memo: Dict[Any, Any]) -> "ComponentTool":
+        # Jinja2 templates throw an Exception when we deepcopy them (see https://github.com/pallets/jinja/issues/758)
+        # When we use a ComponentTool in a pipeline at runtime, we deepcopy the tool
+        # We overwrite ComponentTool.__deepcopy__ to fix this in experimental until a more comprehensive fix is merged.
+        # We track the issue here: https://github.com/deepset-ai/haystack/issues/9011
+        result = copy(self)
+
+        # Add the object to the memo dictionary to handle circular references
+        memo[id(self)] = result
+
+        # Deep copy all attributes with exception handling
+        for key, value in self.__dict__.items():
+            try:
+                # Try to deep copy the attribute
+                setattr(result, key, deepcopy(value, memo))
+            except TypeError:
+                # Fall back to using the original attribute for components that use Jinja2-templates
+                logger.debug(
+                    "deepcopy of ComponentTool {tool_name} failed. Using original attribute '{attribute}' instead.",
+                    tool_name=self.name,
+                    attribute=key,
+                )
+                setattr(result, key, getattr(self, key))
+
+        return result


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/9011

### Proposed Changes:

To unblock building agents with ComponentTools, we fix the error from the referenced issue here until we find a more comprehensive fix.

### How did you test it?

unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
