### PR TITLE
refactor: Rename `inputs` to `inputs_from_state` and `outputs` to `outputs_to_state`

### DIFF
--- a/haystack_experimental/components/tools/tool_invoker.py
+++ b/haystack_experimental/components/tools/tool_invoker.py
@@ -206,9 +206,9 @@ class ToolInvoker:
             func_params = set(inspect.signature(tool.function).parameters.keys())
 
         # Determine the source of parameter mappings (explicit tool inputs or direct function parameters)
-        # Typically, a "Tool" might have .inputs = {"state_key": "tool_param_name"}
-        if hasattr(tool, "inputs") and isinstance(tool.inputs, dict):
-            param_mappings = tool.inputs
+        # Typically, a "Tool" might have .inputs_from_state = {"state_key": "tool_param_name"}
+        if hasattr(tool, "inputs_from_state") and isinstance(tool.inputs_from_state, dict):
+            param_mappings = tool.inputs_from_state
         else:
             param_mappings = {name: name for name in func_params}
 
@@ -247,14 +247,14 @@ class ToolInvoker:
         if not isinstance(result, dict):
             return result
 
-        # If there is no specific `outputs` mapping, we default to merging all result keys into the state.
-        if not hasattr(tool, "outputs") or not isinstance(tool.outputs, dict):
+        # If there is no specific `outputs_to_state` mapping, we default to merging all result keys into the state.
+        if not hasattr(tool, "outputs_to_state") or not isinstance(tool.outputs_to_state, dict):
             for key, value in result.items():
                 state.set(key, value)
             return result
 
         # Handle tool outputs with specific mapping for message and state updates
-        return self._handle_tool_outputs(tool.outputs, result, state)
+        return self._handle_tool_outputs(tool.outputs_to_state, result, state)
 
     @staticmethod
     def _handle_tool_outputs(outputs: dict, result: dict, state: State) -> Union[dict, str]:

--- a/haystack_experimental/tools/from_function.py
+++ b/haystack_experimental/tools/from_function.py
@@ -129,8 +129,8 @@ def create_tool_from_function(
         description=tool_description,
         parameters=schema,
         function=function,
-        inputs=inputs,
-        outputs=outputs
+        inputs_from_state=inputs,
+        outputs_to_state=outputs
     )
 
 

--- a/haystack_experimental/tools/tool.py
+++ b/haystack_experimental/tools/tool.py
@@ -28,11 +28,11 @@ class Tool:
         A JSON schema defining the parameters expected by the Tool.
     :param function:
         The function that will be invoked when the Tool is called.
-    :param inputs:
+    :param inputs_from_state:
         Optional dictionary mapping state keys to tool parameter names.
         Example: {"repository": "repo"} maps state's "repository" to tool's "repo" parameter.
-    :param outputs:
-        Optional dictionary defining how tool outputs map to state and message handling.
+    :param outputs_to_state:
+        Optional dictionary defining how tool outputs map to keys within state as well as optional handlers.
         Example: {
             "documents": {"source": "docs", "handler": custom_handler},
             "message": {"source": "summary", "handler": format_summary}
@@ -43,8 +43,8 @@ class Tool:
     description: str
     parameters: Dict[str, Any]
     function: Callable
-    inputs: Optional[Dict[str, str]] = None
-    outputs: Optional[Dict[str, Dict[str, Any]]] = None
+    inputs_from_state: Optional[Dict[str, str]] = None
+    outputs_to_state: Optional[Dict[str, Dict[str, Any]]] = None
 
     def __post_init__(self):
         # Check that the parameters define a valid JSON schema
@@ -54,8 +54,8 @@ class Tool:
             raise ValueError("The provided parameters do not define a valid JSON schema") from e
 
         # Validate outputs structure if provided
-        if self.outputs is not None:
-            for key, config in self.outputs.items():
+        if self.outputs_to_state is not None:
+            for key, config in self.outputs_to_state.items():
                 if not isinstance(config, dict):
                     raise ValueError(f"Output configuration for key '{key}' must be a dictionary")
                 if "source" in config and not isinstance(config["source"], str):
@@ -91,14 +91,14 @@ class Tool:
         data["function"] = serialize_callable(self.function)
 
         # Serialize output handlers if they exist
-        if self.outputs:
+        if self.outputs_to_state:
             serialized_outputs = {}
-            for key, config in self.outputs.items():
+            for key, config in self.outputs_to_state.items():
                 serialized_config = config.copy()
                 if "handler" in config:
                     serialized_config["handler"] = serialize_callable(config["handler"])
                 serialized_outputs[key] = serialized_config
-            data["outputs"] = serialized_outputs
+            data["outputs_to_state"] = serialized_outputs
 
         return {"type": generate_qualified_class_name(type(self)), "data": data}
 
@@ -116,14 +116,14 @@ class Tool:
         init_parameters["function"] = deserialize_callable(init_parameters["function"])
 
         # Deserialize output handlers if they exist
-        if "outputs" in init_parameters and init_parameters["outputs"]:
+        if "outputs_to_state" in init_parameters and init_parameters["outputs_to_state"]:
             deserialized_outputs = {}
-            for key, config in init_parameters["outputs"].items():
+            for key, config in init_parameters["outputs_to_state"].items():
                 deserialized_config = config.copy()
                 if "handler" in config:
                     deserialized_config["handler"] = deserialize_callable(config["handler"])
                 deserialized_outputs[key] = deserialized_config
-            init_parameters["outputs"] = deserialized_outputs
+            init_parameters["outputs_to_state"] = deserialized_outputs
 
         return cls(**init_parameters)
 

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -114,7 +114,7 @@ class TestToolInvoker:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            inputs={"loc": "location"}
+            inputs_from_state={"loc": "location"}
         )
         state = State(schema={"location": {"type": str}}, data={"loc": "Berlin"})
         args = ToolInvoker._inject_state_args(tool=weather_tool, llm_args={}, state=state)
@@ -297,8 +297,8 @@ class TestToolInvoker:
                                         "required": ["location"],
                                     },
                                     "function": "test.components.tools.test_tool_invoker.weather_function",
-                                    "inputs": None,
-                                    "outputs": None,
+                                    "inputs_from_state": None,
+                                    "outputs_to_state": None,
                                 },
                             }
                         ],
@@ -363,7 +363,7 @@ class TestMergeToolOutputs:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            outputs={"weather": {"source": "weather"}}
+            outputs_to_state={"weather": {"source": "weather"}}
         )
         invoker = ToolInvoker(tools=[weather_tool])
         state = State(schema={"weather": {"type": str}})
@@ -381,7 +381,7 @@ class TestMergeToolOutputs:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            outputs={"weather": {}}
+            outputs_to_state={"weather": {}}
         )
         invoker = ToolInvoker(tools=[weather_tool])
         state = State(schema={"weather": {"type": str}})
@@ -400,7 +400,7 @@ class TestMergeToolOutputs:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            outputs={"temperature": {"source": "temperature", "handler": handler}}
+            outputs_to_state={"temperature": {"source": "temperature", "handler": handler}}
         )
         invoker = ToolInvoker(tools=[weather_tool])
         state = State(schema={"temperature": {"type": str}})
@@ -418,7 +418,7 @@ class TestMergeToolOutputs:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            outputs={"message": {"source": "weather"}}
+            outputs_to_state={"message": {"source": "weather"}}
         )
         invoker = ToolInvoker(tools=[weather_tool])
         state = State(schema={})

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -158,10 +158,10 @@ class TestToolComponent:
     def test_from_component_with_inputs(self):
         component = SimpleComponent()
 
-        tool = ComponentTool(component=component, inputs={"text": "text"})
+        tool = ComponentTool(component=component, inputs_from_state={"text": "text"})
 
 
-        assert tool.inputs == {"text": "text"}
+        assert tool.inputs_from_state == {"text": "text"}
         # Inputs should be excluded from schema generation
         assert tool.parameters == {
             "type": "object",
@@ -171,9 +171,9 @@ class TestToolComponent:
     def test_from_component_with_outputs(self):
         component = SimpleComponent()
 
-        tool = ComponentTool(component=component, outputs={"replies": {"source": "reply"}})
+        tool = ComponentTool(component=component, outputs_to_state={"replies": {"source": "reply"}})
 
-        assert tool.outputs == {"replies": {"source": "reply"}}
+        assert tool.outputs_to_state == {"replies": {"source": "reply"}}
 
     def test_from_component_with_dataclass(self):
         component = UserGreeter()
@@ -578,8 +578,8 @@ class TestToolComponentInPipelineWithOpenAI:
             component=component,
             name="simple_tool",
             description="A simple tool",
-            inputs={"test": "input"},
-            outputs={"output": {"source": "out", "handler": output_handler}},
+            inputs_from_state={"test": "input"},
+            outputs_to_state={"output": {"source": "out", "handler": output_handler}},
         )
 
         # Test serialization
@@ -596,8 +596,8 @@ class TestToolComponentInPipelineWithOpenAI:
         assert new_tool.name == tool.name
         assert new_tool.description == tool.description
         assert new_tool.parameters == tool.parameters
-        assert new_tool.inputs == tool.inputs
-        assert new_tool.outputs == tool.outputs
+        assert new_tool.inputs_from_state == tool.inputs_from_state
+        assert new_tool.outputs_to_state == tool.outputs_to_state
         assert isinstance(new_tool._component, SimpleComponent)
 
     def test_pipeline_component_fails(self):

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -160,8 +160,8 @@ def test_tool_decorator_with_inputs_and_outputs():
 
 
     assert get_weather.name == "get_weather"
-    assert get_weather.inputs == {"format": "format"}
-    assert get_weather.outputs == {"output": {"source": "output"}}
+    assert get_weather.inputs_from_state == {"format": "format"}
+    assert get_weather.outputs_to_state == {"output": {"source": "output"}}
     # Inputs should be excluded from auto-generated parameters
     assert get_weather.parameters == {
         "type": "object",

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -24,8 +24,8 @@ class TestTool:
         assert tool.description == "Get weather report"
         assert tool.parameters == parameters
         assert tool.function == get_weather_report
-        assert tool.inputs is None
-        assert tool.outputs is None
+        assert tool.inputs_from_state is None
+        assert tool.outputs_to_state is None
 
     def test_init_invalid_parameters(self):
         parameters = {"type": "invalid", "properties": {"city": {"type": "string"}}}
@@ -47,7 +47,7 @@ class TestTool:
                 description="irrelevant",
                 parameters=parameters,
                 function=get_weather_report,
-                outputs=outputs
+                outputs_to_state=outputs
             )
 
     def test_tool_spec(self):
@@ -75,7 +75,7 @@ class TestTool:
     def test_to_dict(self):
         tool = Tool(
             name="weather", description="Get weather report", parameters=parameters, function=get_weather_report,
-            outputs={"documents": {"handler": get_weather_report, "source": "docs"}},
+            outputs_to_state={"documents": {"handler": get_weather_report, "source": "docs"}},
         )
 
         assert tool.to_dict() == {
@@ -85,8 +85,8 @@ class TestTool:
                 "description": "Get weather report",
                 "parameters": parameters,
                 "function": "test.tools.test_tool.get_weather_report",
-                "inputs": None,
-                "outputs": {"documents": {"source": "docs", "handler": "test.tools.test_tool.get_weather_report"}},
+                "inputs_from_state": None,
+                "outputs_to_state": {"documents": {"source": "docs", "handler": "test.tools.test_tool.get_weather_report"}},
             },
         }
 
@@ -98,7 +98,7 @@ class TestTool:
                 "description": "Get weather report",
                 "parameters": parameters,
                 "function": "test.tools.test_tool.get_weather_report",
-                "outputs": {"documents": {"source": "docs", "handler": "test.tools.test_tool.get_weather_report"}},
+                "outputs_to_state": {"documents": {"source": "docs", "handler": "test.tools.test_tool.get_weather_report"}},
             },
         }
 
@@ -108,8 +108,8 @@ class TestTool:
         assert tool.description == "Get weather report"
         assert tool.parameters == parameters
         assert tool.function == get_weather_report
-        assert tool.outputs["documents"]["source"] == "docs"
-        assert tool.outputs["documents"]["handler"] == get_weather_report
+        assert tool.outputs_to_state["documents"]["source"] == "docs"
+        assert tool.outputs_to_state["documents"]["handler"] == get_weather_report
 
 
 


### PR DESCRIPTION
### Related Issues

- partially addresses https://github.com/deepset-ai/haystack-experimental/issues/237

Specifically the first task of renaming the new variables added to Tool to make them more clear

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Finish rename of inputs and outputs to inputs_from_state and outputs_to_state

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
**Note**: This is a breaking change

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
