### PR TITLE
feat: Updates to insertion of values into `State`

### DIFF
--- a/haystack_experimental/components/tools/tool_invoker.py
+++ b/haystack_experimental/components/tools/tool_invoker.py
@@ -247,7 +247,7 @@ class ToolInvoker:
         if not isinstance(result, dict):
             return result
 
-        # If there is no specific `outputs` mapping, we jus
+        # If there is no specific `outputs` mapping, we just return the full result
         if not hasattr(tool, "outputs") or not isinstance(tool.outputs, dict):
             return result
 

--- a/haystack_experimental/components/tools/tool_invoker.py
+++ b/haystack_experimental/components/tools/tool_invoker.py
@@ -227,9 +227,9 @@ class ToolInvoker:
         It also determines what message, if any, should be returned for further processing in a conversation.
 
         Processing Steps:
-        1. If `result` is not a dictionary, it is treated as a single output and returned directly.
-        2. If the `tool` does not define an `outputs` mapping, the entire `result` dictionary is merged into the state
-           as key-value pairs. The return value in this case is simply the full `result` dictionary.
+        1. If `result` is not a dictionary, nothing is stored into state and the full `result` is returned.
+        2. If the `tool` does not define an `outputs` mapping nothing is stored into state.
+           The return value in this case is simply the full `result` dictionary.
         3. If the tool defines an `outputs` mapping (a dictionary describing how the tool's output should be processed),
            the method delegates to `_handle_tool_outputs` to process the output accordingly.
            This allows certain fields in `result` to be mapped explicitly to state fields or formatted using custom
@@ -247,10 +247,8 @@ class ToolInvoker:
         if not isinstance(result, dict):
             return result
 
-        # If there is no specific `outputs` mapping, we default to merging all result keys into the state.
+        # If there is no specific `outputs` mapping, we jus
         if not hasattr(tool, "outputs") or not isinstance(tool.outputs, dict):
-            for key, value in result.items():
-                state.set(key, value)
             return result
 
         # Handle tool outputs with specific mapping for message and state updates

--- a/haystack_experimental/components/tools/tool_invoker.py
+++ b/haystack_experimental/components/tools/tool_invoker.py
@@ -228,14 +228,14 @@ class ToolInvoker:
 
         Processing Steps:
         1. If `result` is not a dictionary, nothing is stored into state and the full `result` is returned.
-        2. If the `tool` does not define an `outputs` mapping nothing is stored into state.
+        2. If the `tool` does not define an `outputs_to_state` mapping nothing is stored into state.
            The return value in this case is simply the full `result` dictionary.
-        3. If the tool defines an `outputs` mapping (a dictionary describing how the tool's output should be processed),
-           the method delegates to `_handle_tool_outputs` to process the output accordingly.
+        3. If the tool defines an `outputs_to_state` mapping (a dictionary describing how the tool's output should be
+           processed), the method delegates to `_handle_tool_outputs` to process the output accordingly.
            This allows certain fields in `result` to be mapped explicitly to state fields or formatted using custom
            handlers.
 
-        :param tool: Tool instance containing optional `outputs` mapping to guide result processing.
+        :param tool: Tool instance containing optional `outputs_to_state` mapping to guide result processing.
         :param result: The output from tool execution. Can be a dictionary, or any other type.
         :param state: The global State object to which results should be merged.
         :returns: Three possible values:
@@ -247,7 +247,7 @@ class ToolInvoker:
         if not isinstance(result, dict):
             return result
 
-        # If there is no specific `outputs` mapping, we just return the full result
+        # If there is no specific `outputs_to_state` mapping, we just return the full result
         if not hasattr(tool, "outputs_to_state") or not isinstance(tool.outputs_to_state, dict):
             return result
 
@@ -255,18 +255,18 @@ class ToolInvoker:
         return self._handle_tool_outputs(tool.outputs_to_state, result, state)
 
     @staticmethod
-    def _handle_tool_outputs(outputs: dict, result: dict, state: State) -> Union[dict, str]:
+    def _handle_tool_outputs(outputs_to_state: dict, result: dict, state: State) -> Union[dict, str]:
         """
-        Handles the `outputs` mapping from the tool and updates the state accordingly.
+        Handles the `outputs_to_state` mapping from the tool and updates the state accordingly.
 
-        :param outputs: Mapping of outputs from the tool.
+        :param outputs_to_state: Mapping of outputs from the tool.
         :param result: Result of the tool execution.
         :param state: Global state to merge results into.
         :returns: Final message for LLM or the entire result.
         """
         message_content = None
 
-        for state_key, config in outputs.items():
+        for state_key, config in outputs_to_state.items():
             # Get the source key from the output config, otherwise use the entire result
             source_key = config.get("source", None)
             output_value = result if source_key is None else result.get(source_key)

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -133,8 +133,7 @@ class State:
         Set or merge a value in the state according to schema rules.
 
         Value is merged or overwritten according to these rules:
-          - if the current value in the state is None, replace it
-          - else if handler_override is given, use that
+          - if handler_override is given, use that
           - else use the handler defined in the schema for 'key'
 
         :param key: Key to store the value under

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -155,11 +155,6 @@ class State:
 
         # if the current value is None just replace
         current_value = self._data.get(key, None)
-        if current_value is None:
-            self._data[key] = value
-            return
-
-        # if the current value is not None, we need to merge
         handler = handler_override or definition["handler"]
         self._data[key] = handler(current_value, value)
 

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -8,8 +8,7 @@ from haystack import logging
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.type_serialization import deserialize_type, serialize_type
 
-from haystack_experimental.dataclasses.state_utils import _is_valid_type, _is_list_type, merge_lists, replace_values
-
+from haystack_experimental.dataclasses.state_utils import _is_list_type, _is_valid_type, merge_lists, replace_values
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +106,7 @@ class State:
         self._data = data or {}
 
         # Set default handlers if not provided in schema
-        for key, definition in schema.items():
+        for definition in schema.values():
             # Skip if handler is already defined and not None
             if definition.get("handler") is not None:
                 continue

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -146,7 +146,7 @@ class State:
         if definition is None:
             raise ValueError(f"State: Key '{key}' not found in schema. Schema: {self.schema}")
 
-        # if the current value is None just replace
+        # Get current value from state and apply handler
         current_value = self._data.get(key, None)
         handler = handler_override or definition["handler"]
         self._data[key] = handler(current_value, value)

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -4,10 +4,14 @@
 
 from typing import Any, Callable, Dict, Optional
 
+from haystack import logging
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.type_serialization import deserialize_type, serialize_type
 
-from haystack_experimental.dataclasses.state_utils import _is_valid_type, merge_values
+from haystack_experimental.dataclasses.state_utils import _is_valid_type, _is_list_type, merge_lists, replace_values
+
+
+logger = logging.getLogger(__name__)
 
 
 def _schema_to_dict(schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -78,7 +82,7 @@ class State:
     A dataclass that wraps a StateSchema and maintains an internal _data dictionary.
 
     Each schema entry has:
-      {
+      "parameter_name": {
         "type": SomeType,
         "handler": Optional[Callable[[Any, Any], Any]]
       }
@@ -88,13 +92,30 @@ class State:
         schema: Dict[str, Any],
         data: Optional[Dict[str, Any]] = None
     ):
+        """
+        Initialize a State object with a schema and optional data.
+
+        :param schema: Dictionary mapping parameter names to their type and handler configs.
+            Type must be a valid Python type, and handler must be a callable function or None.
+            If handler is None, the default handler for the type will be used. The default handlers are:
+                - For list types: `haystack_experimental.dataclasses.state_utils.merge_lists`
+                - For all other types: `haystack_experimental.dataclasses.state_utils.replace_values`
+        :param data: Optional dictionary of initial data to populate the state
+        """
         _validate_schema(schema)
         self.schema = schema
         self._data = data or {}
 
-        if data:
-            for key, val in data.items():
-                self.set(key, val, force=True)
+        # Set default handlers if not provided in schema
+        for key, definition in schema.items():
+            # Skip if handler is already defined and not None
+            if definition.get("handler") is not None:
+                continue
+            # Set default handler based on type
+            if _is_list_type(definition["type"]):
+                definition["handler"] = merge_lists
+            else:
+                definition["handler"] = replace_values
 
     def get(self, key: str, default: Any = None) -> Any:
         """
@@ -110,50 +131,37 @@ class State:
         self,
         key: str,
         value: Any,
-        handler_override: Optional[Callable[[Any, Any], Any]] = None,
-        force: bool = False
+        handler_override: Optional[Callable[[Any, Any], Any]] = None
     ) -> None:
         """
         Set or merge a value in the state according to schema rules.
 
         Value is merged or overwritten according to these rules:
-          - If force=True, just overwrite
+          - if the current value in the state is None, replace it
           - else if handler_override is given, use that
-          - else if the schema for 'key' has a custom handler, use it
-          - else use default merge logic
+          - else use the handler defined in the schema for 'key'
 
         :param key: Key to store the value under
         :param value: Value to store or merge
-        :param handler_override: Optional function to override default merge behavior
-        :param force: If True, overwrites existing value without merging
+        :param handler_override: Optional function to override the default merge behavior
         """
-        # If key not in schema, we consider no special merging => just store
-        definition = self.schema.get(key, {})
-        declared_type = definition.get("type")
-        declared_handler = definition.get("handler")
+        # If key not in schema, we throw an error
+        definition = self.schema.get(key, None)
+        if definition is None:
+            logger.error(
+                "State: Key '{state_key}' not found in schema. Schema: {schema}", state_key=key, schema=self.schema
+            )
+            raise ValueError(f"State: Key '{key}' not found in schema. Schema: {self.schema}")
 
-        if force or (not declared_type and not declared_handler and not handler_override):
-            self._data[key] = value
-            return
-
+        # if the current value is None just replace
         current_value = self._data.get(key, None)
-
-        # if the current value was None and no merging needed, just store
-        if current_value is None and not declared_handler and not handler_override:
+        if current_value is None:
             self._data[key] = value
             return
 
-        # pick the handler (override > declared > default)
-        handler = handler_override or declared_handler
-        if handler:
-            self._data[key] = handler(current_value, value)
-        else:
-            # default merging
-            if declared_type is None:
-                # no known type => just replace
-                self._data[key] = value
-            else:
-                self._data[key] = merge_values(current_value, value, declared_type)
+        # if the current value is not None, we need to merge
+        handler = handler_override or definition["handler"]
+        self._data[key] = handler(current_value, value)
 
     @property
     def data(self):

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -4,13 +4,10 @@
 
 from typing import Any, Callable, Dict, Optional
 
-from haystack import logging
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.type_serialization import deserialize_type, serialize_type
 
 from haystack_experimental.dataclasses.state_utils import _is_list_type, _is_valid_type, merge_lists, replace_values
-
-logger = logging.getLogger(__name__)
 
 
 def _schema_to_dict(schema: Dict[str, Any]) -> Dict[str, Any]:

--- a/haystack_experimental/dataclasses/state.py
+++ b/haystack_experimental/dataclasses/state.py
@@ -147,9 +147,6 @@ class State:
         # If key not in schema, we throw an error
         definition = self.schema.get(key, None)
         if definition is None:
-            logger.error(
-                "State: Key '{state_key}' not found in schema. Schema: {schema}", state_key=key, schema=self.schema
-            )
             raise ValueError(f"State: Key '{key}' not found in schema. Schema: {self.schema}")
 
         # if the current value is None just replace

--- a/haystack_experimental/dataclasses/state_utils.py
+++ b/haystack_experimental/dataclasses/state_utils.py
@@ -35,8 +35,7 @@ def _is_valid_type(obj: Any) -> bool:
         return True
 
     # Handle normal classes and generic types
-    return (inspect.isclass(obj) or
-            type(obj).__name__ in {"_GenericAlias", "GenericAlias"})
+    return inspect.isclass(obj) or type(obj).__name__ in {"_GenericAlias", "GenericAlias"}
 
 
 def _is_list_type(type_hint: Any) -> bool:
@@ -57,6 +56,11 @@ def merge_lists(current: Union[List[T], T], new: Union[List[T], T]) -> List[T]:
     :param new: The new value to merge, which may or may not be a list
     :return: A new list containing the merged values
     """
+    # If the current value is None, return the new value as a list
+    if current is None:
+        return new if isinstance(new, list) else [new]
+
+    # If the current value is not none, then merge
     current_list = current if isinstance(current, list) else [current]
     new_list = new if isinstance(new, list) else [new]
     return current_list + new_list

--- a/haystack_experimental/dataclasses/state_utils.py
+++ b/haystack_experimental/dataclasses/state_utils.py
@@ -50,25 +50,25 @@ def _is_list_type(type_hint: Any) -> bool:
 
 def merge_lists(current: Union[List[T], T], new: Union[List[T], T]) -> List[T]:
     """
-    Merge two values according to list merging rules.
+    Merges two values into a single list.
 
-    :param current: The current value, which may or may not be a list
-    :param new: The new value to merge, which may or may not be a list
-    :return: A new list containing the merged values
+    If either `current` or `new` is not already a list, it is converted into one.
+    The function ensures that both inputs are treated as lists and concatenates them.
+
+    If `current` is None, it is treated as an empty list.
+
+    :param current: The existing value(s), either a single item or a list.
+    :param new: The new value(s) to merge, either a single item or a list.
+    :return: A list containing elements from both `current` and `new`.
     """
-    # If the current value is None, return the new value as a list
-    if current is None:
-        return new if isinstance(new, list) else [new]
-
-    # If the current value is not none, then merge
-    current_list = current if isinstance(current, list) else [current]
+    current_list = [] if current is None else current if isinstance(current, list) else [current]
     new_list = new if isinstance(new, list) else [new]
     return current_list + new_list
 
 
 def replace_values(current: Any, new: Any) -> Any:
     """
-    Replace the current value with the new value.
+    Replace the `current` value with the `new` value.
 
     :param current: The existing value
     :param new: The new value to replace

--- a/haystack_experimental/dataclasses/state_utils.py
+++ b/haystack_experimental/dataclasses/state_utils.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
-from typing import Any, Dict, List, TypeVar, Union, get_origin
+from typing import Any, List, TypeVar, Union, get_origin
+
+T = TypeVar("T")
 
 
 def _is_valid_type(obj: Any) -> bool:
@@ -37,11 +39,7 @@ def _is_valid_type(obj: Any) -> bool:
             type(obj).__name__ in {"_GenericAlias", "GenericAlias"})
 
 
-
-T = TypeVar("T")
-
-
-def is_list_type(type_hint: Any) -> bool:
+def _is_list_type(type_hint: Any) -> bool:
     """
     Check if a type hint represents a list type.
 
@@ -51,17 +49,7 @@ def is_list_type(type_hint: Any) -> bool:
     return type_hint is list or (hasattr(type_hint, "__origin__") and get_origin(type_hint) is list)
 
 
-def is_dict_type(type_hint: Any) -> bool:
-    """
-    Check if a type hint represents a dict type.
-
-    :param type_hint: The type hint to check
-    :return: True if the type hint represents a dict, False otherwise
-    """
-    return type_hint is dict or (hasattr(type_hint, "__origin__") and get_origin(type_hint) is dict)
-
-
-def merge_lists(current: Union[List[T], Any], new: Union[List[T], T]) -> List[T]:
+def merge_lists(current: Union[List[T], T], new: Union[List[T], T]) -> List[T]:
     """
     Merge two values according to list merging rules.
 
@@ -69,49 +57,17 @@ def merge_lists(current: Union[List[T], Any], new: Union[List[T], T]) -> List[T]
     :param new: The new value to merge, which may or may not be a list
     :return: A new list containing the merged values
     """
-    if isinstance(current, list):
-        if isinstance(new, list):
-            return [*current, *new]  # Extend
-        return [*current, new]  # Append
-    if isinstance(new, list):
-        return new  # Replace
-    return [current, new]  # Create new list
+    current_list = current if isinstance(current, list) else [current]
+    new_list = new if isinstance(new, list) else [new]
+    return current_list + new_list
 
 
-def merge_dicts(current: Union[Dict[str, T], T], new: Union[Dict[str, T], T]) -> Union[Dict[str, T], T]:
+def replace_values(current: Any, new: Any) -> Any:
     """
-    Merge two values according to dict merging rules.
+    Replace the current value with the new value.
 
-    :param current: The current value, which may or may not be a dict
-    :param new: The new value to merge, which may or may not be a dict
-    :return: A new dict containing the merged values if both inputs are dicts, otherwise the new value
+    :param current: The existing value
+    :param new: The new value to replace
+    :return: The new value
     """
-    if isinstance(current, dict) and isinstance(new, dict):
-        return {**current, **new}  # Update
-    return new  # Replace
-
-
-def merge_values(current_value: Any, new_value: Any, declared_type: Any) -> Any:
-    """
-    Merge values based on their types and declared type hint.
-
-    Rules:
-    - Lists: extend if new value is also a list, otherwise append
-    - Dicts: shallow update if both are dicts, otherwise replace
-    - Others: replace entirely
-
-    :param current_value: The existing value
-    :param new_value: The new value to merge
-    :param declared_type: The type hint for the value
-    :return: The merged value according to the merging rules
-    """
-    if current_value is None:
-        return new_value
-
-    if is_list_type(declared_type):
-        return merge_lists(current_value, new_value)
-
-    if is_dict_type(declared_type):
-        return merge_dicts(current_value, new_value)
-
-    return new_value  # Default: replace
+    return new

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -355,7 +355,7 @@ class TestMergeToolOutputs:
             state=state
         )
         assert merged_results == {"weather": "sunny", "temperature": 14, "unit": "celsius"}
-        assert state.data == {"weather": "sunny", "temperature": 14, "unit": "celsius"}
+        assert state.data == {}
 
     def test_merge_tool_outputs_with_output_mapping(self):
         weather_tool = Tool(

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -381,17 +381,17 @@ class TestMergeToolOutputs:
             description="Provides weather information for a given location.",
             parameters=weather_parameters,
             function=weather_function,
-            outputs_to_state={"weather": {}}
+            outputs_to_state={"all_weather_results": {}}
         )
         invoker = ToolInvoker(tools=[weather_tool])
-        state = State(schema={"weather": {"type": str}})
+        state = State(schema={"all_weather_results": {"type": str}})
         merged_results = invoker._merge_tool_outputs(
             tool=weather_tool,
             result={"weather": "sunny", "temperature": 14, "unit": "celsius"},
             state=state
         )
         assert merged_results == {"weather": "sunny", "temperature": 14, "unit": "celsius"}
-        assert state.data == {"weather": {"weather": "sunny", "temperature": 14, "unit": "celsius"}}
+        assert state.data == {"all_weather_results": {"weather": "sunny", "temperature": 14, "unit": "celsius"}}
 
     def test_merge_tool_outputs_with_output_mapping_and_handler(self):
         handler = lambda old, new: f"{new}"

--- a/test/dataclasses/test_state.py
+++ b/test/dataclasses/test_state.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 
 from haystack_experimental.dataclasses.state import State, _validate_schema
 
-# Test fixtures
+
 @pytest.fixture
 def basic_schema():
     return {
@@ -25,7 +25,6 @@ def complex_schema():
     }
 
 
-# Test _validate_schema
 def test_validate_schema_valid(basic_schema):
     # Should not raise any exceptions
     _validate_schema(basic_schema)
@@ -55,7 +54,6 @@ def test_validate_schema_invalid_handler():
         _validate_schema(invalid_schema)
 
 
-# Test State class
 def test_state_initialization(basic_schema):
     # Test empty initialization
     state = State(basic_schema)
@@ -98,17 +96,6 @@ def test_state_set_with_handler(complex_schema):
     assert state.get("numbers") == [1, 2, 3, 4, 5, 6]
 
 
-def test_state_set_with_force(basic_schema):
-    state = State(basic_schema)
-
-    # Set initial value
-    state.set("numbers", [1, 2])
-
-    # Force update should replace instead of merge
-    state.set("numbers", [3, 4], force=True)
-    assert state.get("numbers") == [3, 4]
-
-
 def test_state_set_with_handler_override(basic_schema):
     state = State(basic_schema)
 
@@ -125,12 +112,12 @@ def test_state_has(basic_schema):
     assert state.has("name") is True
     assert state.has("non_existent") is False
 
-# Test edge cases
+
 def test_state_empty_schema():
     state = State({})
     assert state.data == {}
-    state.set("any_key", "value")  # Should work with empty schema
-    assert state.get("any_key") == "value"
+    with pytest.raises(ValueError, match="Key 'any_key' not found in schema"):
+        state.set("any_key", "value")
 
 
 def test_state_none_values(basic_schema):
@@ -141,18 +128,14 @@ def test_state_none_values(basic_schema):
     assert state.get("name") == "value"
 
 
-def test_state_invalid_types(basic_schema):
+def test_state_merge_lists(basic_schema):
     state = State(basic_schema)
-    # Setting wrong type should still work (Python's dynamic typing)
     state.set("numbers", "not_a_list")
-    assert state.get("numbers") == "not_a_list"
-
-    # Next set with correct type should handle the invalid previous value
+    assert state.get("numbers") == ["not_a_list"]
     state.set("numbers", [1, 2])
-    assert state.get("numbers") == [1, 2]
+    assert state.get("numbers") == ["not_a_list", 1, 2]
 
 
-# Test complex nested structures
 def test_state_nested_structures():
     schema = {
         "complex": {

--- a/test/dataclasses/test_state_utils.py
+++ b/test/dataclasses/test_state_utils.py
@@ -2,18 +2,18 @@ import pytest
 from typing import Any, List, Dict, Optional, Union, TypeVar, Generic
 from dataclasses import dataclass
 
-from haystack_experimental.dataclasses.state_utils import merge_values, is_list_type, is_dict_type, merge_lists, merge_dicts, _is_valid_type
+from haystack_experimental.dataclasses.state_utils import merge_values, _is_list_type, is_dict_type, merge_lists, merge_dicts, _is_valid_type
 
 import inspect
 
 def test_is_list_type():
     """Test the list type detection function."""
-    assert is_list_type(list) is True
-    assert is_list_type(List[int]) is True
-    assert is_list_type(List[str]) is True
-    assert is_list_type(dict) is False
-    assert is_list_type(int) is False
-    assert is_list_type(Union[List[int], None]) is False
+    assert _is_list_type(list) is True
+    assert _is_list_type(List[int]) is True
+    assert _is_list_type(List[str]) is True
+    assert _is_list_type(dict) is False
+    assert _is_list_type(int) is False
+    assert _is_list_type(Union[List[int], None]) is False
 
 
 def test_is_dict_type():

--- a/test/dataclasses/test_state_utils.py
+++ b/test/dataclasses/test_state_utils.py
@@ -1,13 +1,13 @@
 import pytest
-from typing import Any, List, Dict, Optional, Union, TypeVar, Generic
+from typing import List, Dict, Optional, Union, TypeVar, Generic
 from dataclasses import dataclass
 
-from haystack_experimental.dataclasses.state_utils import merge_values, _is_list_type, is_dict_type, merge_lists, merge_dicts, _is_valid_type
+from haystack_experimental.dataclasses.state_utils import _is_list_type, merge_lists, _is_valid_type
 
 import inspect
 
+
 def test_is_list_type():
-    """Test the list type detection function."""
     assert _is_list_type(list) is True
     assert _is_list_type(List[int]) is True
     assert _is_list_type(List[str]) is True
@@ -16,21 +16,8 @@ def test_is_list_type():
     assert _is_list_type(Union[List[int], None]) is False
 
 
-def test_is_dict_type():
-    """Test the dict type detection function."""
-    assert is_dict_type(dict) is True
-    assert is_dict_type(Dict[str, int]) is True
-    assert is_dict_type(Dict[str, Any]) is True
-    assert is_dict_type(list) is False
-    assert is_dict_type(int) is False
-    assert is_dict_type(Union[Dict[str, int], None]) is False
-
-
 class TestMergeLists:
-    """Test cases for list merging functionality."""
-
     def test_merge_two_lists(self):
-        """Test merging two lists."""
         current = [1, 2, 3]
         new = [4, 5, 6]
         result = merge_lists(current, new)
@@ -40,7 +27,6 @@ class TestMergeLists:
         assert new == [4, 5, 6]
 
     def test_append_to_list(self):
-        """Test appending a non-list value to a list."""
         current = [1, 2, 3]
         new = 4
         result = merge_lists(current, new)
@@ -48,109 +34,20 @@ class TestMergeLists:
         assert current == [1, 2, 3]  # Ensure original wasn't modified
 
     def test_create_new_list(self):
-        """Test creating a new list from two non-list values."""
         current = 1
         new = 2
         result = merge_lists(current, new)
         assert result == [1, 2]
 
     def test_replace_with_list(self):
-        """Test replacing a non-list value with a list."""
         current = 1
         new = [2, 3]
         result = merge_lists(current, new)
-        assert result == [2, 3]
-
-
-class TestMergeDicts:
-    """Test cases for dictionary merging functionality."""
-
-    def test_merge_two_dicts(self):
-        """Test merging two dictionaries."""
-        current = {'a': 1, 'b': 2}
-        new = {'c': 3, 'd': 4}
-        result = merge_dicts(current, new)
-        assert result == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
-        # Ensure original dicts weren't modified
-        assert current == {'a': 1, 'b': 2}
-        assert new == {'c': 3, 'd': 4}
-
-    def test_dict_key_override(self):
-        """Test that new dict values override existing ones."""
-        current = {'a': 1, 'b': 2}
-        new = {'b': 3, 'c': 4}
-        result = merge_dicts(current, new)
-        assert result == {'a': 1, 'b': 3, 'c': 4}
-
-    def test_replace_non_dict(self):
-        """Test replacing when either value is not a dict."""
-        assert merge_dicts(42, {'a': 1}) == {'a': 1}
-        assert merge_dicts({'a': 1}, 42) == 42
-        assert merge_dicts(42, 43) == 43
-
-
-class TestMergeValues:
-    """Test cases for the main merge_values function."""
-
-    def test_none_handling(self):
-        """Test handling of None values."""
-        assert merge_values(None, 42, int) == 42
-        assert merge_values(None, [1, 2], List[int]) == [1, 2]
-        assert merge_values(None, {'a': 1}, Dict[str, int]) == {'a': 1}
-
-    def test_list_merging(self):
-        """Test list merging with different types."""
-        # List + List
-        assert merge_values([1, 2], [3, 4], List[int]) == [1, 2, 3, 4]
-        # List + Value
-        assert merge_values([1, 2], 3, List[int]) == [1, 2, 3]
-        # Value + List
-        assert merge_values(1, [2, 3], List[int]) == [2, 3]
-        # Value + Value
-        assert merge_values(1, 2, List[int]) == [1, 2]
-
-    def test_dict_merging(self):
-        """Test dictionary merging with different types."""
-        # Dict + Dict
-        assert merge_values({'a': 1}, {'b': 2}, Dict[str, int]) == {'a': 1, 'b': 2}
-        # Dict + Non-Dict
-        assert merge_values({'a': 1}, 42, Dict[str, int]) == 42
-        # Non-Dict + Dict
-        assert merge_values(42, {'a': 1}, Dict[str, int]) == {'a': 1}
-
-    def test_primitive_replacement(self):
-        """Test primitive value replacement."""
-        assert merge_values(1, 2, int) == 2
-        assert merge_values("old", "new", str) == "new"
-        assert merge_values(1.0, 2.0, float) == 2.0
-
-    @pytest.mark.parametrize(
-        "current,new,type_hint,expected",
-        [
-            ([1, 2], [3, 4], List[int], [1, 2, 3, 4]),
-            ([1, 2], 3, List[int], [1, 2, 3]),
-            ({'a': 1}, {'b': 2}, Dict[str, int], {'a': 1, 'b': 2}),
-            (1, 2, int, 2),
-            (None, 42, int, 42),
-        ]
-    )
-    def test_parametrized_cases(self, current, new, type_hint, expected):
-        """Parametrized test cases for different scenarios."""
-        assert merge_values(current, new, type_hint) == expected
-
-    def test_nested_structures(self):
-        """Test merging nested structures."""
-        current = {'list': [1, 2], 'dict': {'a': 1}}
-        new = {'list': [3, 4], 'dict': {'b': 2}}
-        result = merge_values(current, new, Dict[str, Any])
-        assert result == {'list': [3, 4], 'dict': {'b': 2}}
+        assert result == [1, 2, 3]
 
 
 class TestIsValidType:
-    """Test cases for type validation function."""
-
     def test_builtin_types(self):
-        """Test with built-in Python types."""
         assert _is_valid_type(str) is True
         assert _is_valid_type(int) is True
         assert _is_valid_type(dict) is True
@@ -161,15 +58,12 @@ class TestIsValidType:
         assert _is_valid_type(float) is True
 
     def test_generic_types(self):
-        """Test with generic type hints."""
         assert _is_valid_type(List[str]) is True
         assert _is_valid_type(Dict[str, int]) is True
         assert _is_valid_type(List[Dict[str, int]]) is True
         assert _is_valid_type(Dict[str, List[int]]) is True
 
     def test_custom_classes(self):
-        """Test with custom classes and generic custom classes."""
-
         @dataclass
         class CustomClass:
             value: int
@@ -190,7 +84,6 @@ class TestIsValidType:
         assert _is_valid_type(Dict[str, GenericCustomClass[int]]) is True
 
     def test_invalid_types(self):
-        """Test with invalid type inputs."""
         # Test regular values
         assert _is_valid_type(42) is False
         assert _is_valid_type("string") is False
@@ -212,7 +105,6 @@ class TestIsValidType:
         assert _is_valid_type(print) is False
 
     def test_union_and_optional_types(self):
-        """Test with Union and Optional types."""
         # Test basic Union types
         assert _is_valid_type(Union[str, int]) is True
         assert _is_valid_type(Union[str, None]) is True
@@ -227,14 +119,12 @@ class TestIsValidType:
         assert _is_valid_type(Union) is False
 
     def test_nested_generic_types(self):
-        """Test with deeply nested generic types."""
         assert _is_valid_type(List[List[Dict[str, List[int]]]]) is True
         assert _is_valid_type(Dict[str, List[Dict[str, set]]]) is True
         assert _is_valid_type(Dict[str, Optional[List[int]]]) is True
         assert _is_valid_type(List[Union[str, Dict[str, List[int]]]]) is True
 
     def test_edge_cases(self):
-        """Test edge cases and potential corner cases."""
         # Test None and NoneType
         assert _is_valid_type(None) is False
         assert _is_valid_type(type(None)) is True
@@ -264,5 +154,4 @@ class TestIsValidType:
         (lambda x: x, False),
     ])
     def test_parametrized_cases(self, test_input, expected):
-        """Parametrized test cases for different scenarios."""
         assert _is_valid_type(test_input) is expected


### PR DESCRIPTION
### Related Issues

- partially addresses https://github.com/deepset-ai/haystack-experimental/issues/237

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Addresses these points in the check list

**Tools** and **ToolInvoker**
- [x] In `outputs_to_state` if you omit `source` then put the entire tool result into that key within State
- [x] drop automatic dict merging
- [x] Keep default extend + append logic for List types defined in State Schema —> fix bug in append logic

**State**
- [x] Don’t dump all results into State by default, only listen to `outputs_to_state` defined in `Tool`
- [x] Assign default handlers at State initialization. If a user were to print the State schema it would be ideal for them to be able to see and inspect the default handlers. Currently default behavior is in ToolInvoker and not transparent.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
