### PR TITLE
feat: Add `unclassified` to output of MultiFileConverter

### DIFF
--- a/haystack_experimental/super_components/converters/multi_file_converter.py
+++ b/haystack_experimental/super_components/converters/multi_file_converter.py
@@ -54,13 +54,13 @@ class MultiFileConverter(SuperComponent):
     Usage:
     ```
     from haystack_experimental.super_components.converters import MultiFileConverter
-    
+
     converter = MultiFileConverter()
     converter.run(sources=["test.txt", "test.pdf"], meta={})
     ```
     """
 
-    def __init__( # noqa: PLR0915
+    def __init__(  # noqa: PLR0915
         self,
         encoding: str = "utf-8",
         json_content_key: str = "content",
@@ -88,11 +88,11 @@ class MultiFileConverter(SuperComponent):
                 ConverterMimeType.XLSX.value,
             ],
             # Ensure common extensions are registered. Tests on Windows fail otherwise.
-            additional_mimetypes = {
+            additional_mimetypes={
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx"
-            }
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+            },
         )
 
         csv = CSVToDocument(encoding=self.encoding)
@@ -106,8 +106,6 @@ class MultiFileConverter(SuperComponent):
         xlsx = XLSXToDocument()
 
         joiner = DocumentJoiner()
-
-
 
         # Create pipeline and add components
         pp = Pipeline()
@@ -146,20 +144,11 @@ class MultiFileConverter(SuperComponent):
         pp.connect("csv.documents", "joiner.documents")
         pp.connect("xlsx.documents", "joiner.documents")
 
-
-        output_mapping = {
-            "joiner.documents": "documents",
-            "router.unclassified": "unclassified"
-        }
-        input_mapping = {
-            "sources": ["router.sources"],
-            "meta": ["router.meta"]
-        }
+        output_mapping = {"joiner.documents": "documents", "router.unclassified": "unclassified"}
+        input_mapping = {"sources": ["router.sources"], "meta": ["router.meta"]}
 
         super(MultiFileConverter, self).__init__(
-            pipeline=pp,
-            output_mapping=output_mapping,
-            input_mapping=input_mapping
+            pipeline=pp, output_mapping=output_mapping, input_mapping=input_mapping
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/haystack_experimental/super_components/converters/multi_file_converter.py
+++ b/haystack_experimental/super_components/converters/multi_file_converter.py
@@ -53,6 +53,8 @@ class MultiFileConverter(SuperComponent):
 
     Usage:
     ```
+    from haystack_experimental.super_components.converters import MultiFileConverter
+    
     converter = MultiFileConverter()
     converter.run(sources=["test.txt", "test.pdf"], meta={})
     ```
@@ -145,7 +147,10 @@ class MultiFileConverter(SuperComponent):
         pp.connect("xlsx.documents", "joiner.documents")
 
 
-        output_mapping = {"joiner.documents": "documents"}
+        output_mapping = {
+            "joiner.documents": "documents",
+            "router.unclassified": "unclassified"
+        }
         input_mapping = {
             "sources": ["router.sources"],
             "meta": ["router.meta"]

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -84,7 +84,7 @@ class TestMultiFileConverter:
         assert docs[0].meta["file_path"].endswith(suffix)
 
         assert len(unclassified) == 1
-        assert isinstance(unclassified[0], Union[str, Path, ByteStream])
+        assert isinstance(unclassified[0], ByteStream)
         assert unclassified[0].meta["content_type"] == "unknown_type"
 
     def test_run_with_meta(self, test_files_path, converter):


### PR DESCRIPTION
### Related Issues

- None. I realized `MultiFileConverter` can only be a drop in replacement of the Router-Converters-Joiner combo if we also expose `unclassified`.

### Proposed Changes:

- Add `unclassified` to `MultiFileConverter` `output_mapping`
- Extend integration test

### How did you test it?

- Extended integration test
- Notebook on Google colab: https://colab.research.google.com/drive/1eM0LmSgh30vCd2e58ucA7n_jnw7H3kGh?usp=sharing

### Notes for the reviewer

I added some pipeline visualizations for reference below.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

### What the pipeline should look like with MultiFileConverter (and does with this PR)
![multi-file-converter-before](https://github.com/user-attachments/assets/6f1bf792-fa4a-49b4-b0e7-bee98ab9e099)

### What the pipeline looks like with MultiFileConverter before this PR
![multi-file-converter-after](https://github.com/user-attachments/assets/002e13a7-3a5d-479b-a5af-2bb424b77e64)

### What the pipeline looks like without MultiFileConverter for comparison
![multi-file-converter-before-old](https://github.com/user-attachments/assets/0a2c6bc5-8034-4e76-8d90-9eb4762a068e)