### PR TITLE
feat: Added original error message to ToolInvocationError

### DIFF
--- a/haystack_experimental/tools/tool.py
+++ b/haystack_experimental/tools/tool.py
@@ -77,7 +77,9 @@ class Tool:
         try:
             result = self.function(**kwargs)
         except Exception as e:
-            raise ToolInvocationError(f"Failed to invoke Tool `{self.name}` with parameters {kwargs}") from e
+            raise ToolInvocationError(
+                f"Failed to invoke Tool `{self.name}` with parameters {kwargs}. Error: {e}"
+            ) from e
         return result
 
     def to_dict(self) -> Dict[str, Any]:

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 import pytest
 
 from haystack_experimental.tools.tool import Tool, ToolInvocationError, deserialize_tools_inplace, _check_duplicate_tool_names
@@ -28,10 +29,9 @@ class TestTool:
         assert tool.outputs_to_state is None
 
     def test_init_invalid_parameters(self):
-        parameters = {"type": "invalid", "properties": {"city": {"type": "string"}}}
-
+        params = {"type": "invalid", "properties": {"city": {"type": "string"}}}
         with pytest.raises(ValueError):
-            Tool(name="irrelevant", description="irrelevant", parameters=parameters, function=get_weather_report)
+            Tool(name="irrelevant", description="irrelevant", parameters=params, function=get_weather_report)
 
     @pytest.mark.parametrize("outputs",
     [
@@ -41,11 +41,10 @@ class TestTool:
     ])
     def test_init_invalid_output_structure(self, outputs):
         with pytest.raises(ValueError):
-            parameters = {"type": "object", "properties": {"city": {"type": "string"}}}
             Tool(
                 name="irrelevant",
                 description="irrelevant",
-                parameters=parameters,
+                parameters={"type": "object", "properties": {"city": {"type": "string"}}},
                 function=get_weather_report,
                 outputs_to_state=outputs
             )
@@ -68,8 +67,12 @@ class TestTool:
         tool = Tool(
             name="weather", description="Get weather report", parameters=parameters, function=get_weather_report
         )
-
-        with pytest.raises(ToolInvocationError):
+        with pytest.raises(
+            ToolInvocationError,
+            match=re.escape(
+                "Failed to invoke Tool `weather` with parameters {}. Error: get_weather_report() missing 1 required positional argument: 'city'"
+            )
+        ):
             tool.invoke()
 
     def test_to_dict(self):
@@ -110,7 +113,6 @@ class TestTool:
         assert tool.function == get_weather_report
         assert tool.outputs_to_state["documents"]["source"] == "docs"
         assert tool.outputs_to_state["documents"]["handler"] == get_weather_report
-
 
 
 def test_deserialize_tools_inplace():


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9050

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds the error message from the original exception when raising the ToolInvocationError. This allows us to provide the underlying error in the ChatMessage when using the ToolInvoker so the LLM has a chance to fix the issue.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
