### PR TITLE
refactor: Streamline super components input and output mapping logic

### DIFF
--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -8,7 +8,7 @@ from haystack import Pipeline, component
 from haystack.core.pipeline.utils import parse_connect_string
 from haystack.core.serialization import default_from_dict, default_to_dict, generate_qualified_class_name
 
-from haystack_experimental.core.super_component.utils import _delegate_default, is_compatible
+from haystack_experimental.core.super_component.utils import _delegate_default, _is_compatible
 
 
 class InvalidMappingError(Exception):
@@ -193,7 +193,7 @@ class SuperComponent:
                         aggregated_inputs[wrapper_input_name]["default"] = _delegate_default
                     continue
 
-                if not is_compatible(existing_socket_info["type"], socket_info["type"]):
+                if not _is_compatible(existing_socket_info["type"], socket_info["type"]):
                     raise InvalidMappingError(
                         f"Type conflict for input '{socket_name}' from component '{comp_name}'. "
                         f"Existing type: {existing_socket_info['type']}, new type: {socket_info['type']}."

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -202,9 +202,10 @@ class SuperComponent:
                     )
 
                 # If any socket requires mandatory inputs then the aggregated input is also considered mandatory.
-                # So we use the type of the mandatory input.
+                # So we use the type of the mandatory input and remove the default value if it exists.
                 if socket_info["is_mandatory"]:
                     aggregated_inputs[wrapper_input_name]["type"] = socket_info["type"]
+                    aggregated_inputs[wrapper_input_name].pop("default", None)
 
         return aggregated_inputs
 

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -202,8 +202,6 @@ class SuperComponent:
                     aggregated_inputs[wrapper_input_name] = socket_info
                     continue
 
-                # TODO is_compatible should determine least common denominator of type overlap and set that as the type
-                #      for the wrapper input
                 if not is_compatible(existing_socket_info["type"], socket_info["type"]):
                     raise InvalidMappingError(
                         f"Type conflict for input '{socket_name}' from component '{comp_name}'. "

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -126,8 +126,8 @@ class SuperComponent:
         """
         if self._warmed_up is False:
             raise RuntimeError("SuperComponent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
-
-        pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=kwargs)
+        filtered_inputs = {param: value for param, value in kwargs.items() if value != _delegate_default}
+        pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=filtered_inputs)
         pipeline_outputs = self.pipeline.run(data=pipeline_inputs)
         return self._map_explicit_outputs(pipeline_outputs, self.output_mapping)
 

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -124,8 +124,6 @@ class SuperComponent:
         :raises RuntimeError:
             If the SuperComponent wasn't warmed up before calling 'run()'
         """
-        if self._warmed_up is False:
-            raise RuntimeError("SuperComponent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
         filtered_inputs = {param: value for param, value in kwargs.items() if value != _delegate_default}
         pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=filtered_inputs)
         pipeline_outputs = self.pipeline.run(data=pipeline_inputs)

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -127,8 +127,7 @@ class SuperComponent:
         if self._warmed_up is False:
             raise RuntimeError("SuperComponent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
 
-        filtered_inputs = {param: value for param, value in kwargs.items() if value != _delegate_default}
-        pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=filtered_inputs)
+        pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=kwargs)
         pipeline_outputs = self.pipeline.run(data=pipeline_inputs)
         return self._map_explicit_outputs(pipeline_outputs, self.output_mapping)
 

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -329,7 +329,7 @@ class SuperComponent:
 
     def _process_pipeline_outputs(self, pipeline_outputs: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
         """
-        Process outputs from pipeline execution.
+        Maps pipeline outputs to the SuperComponent outputs.
 
         :param pipeline_outputs: Raw outputs from pipeline execution
         :return: Dictionary of processed outputs

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -220,7 +220,7 @@ class SuperComponent:
         """
         input_mapping: Dict[str, List[str]] = {}
         for comp_name, inputs_dict in pipeline_inputs.items():
-            for socket_name, socket_info in inputs_dict.items():
+            for socket_name in inputs_dict.keys():
                 existing_socket_info = input_mapping.get(socket_name)
                 if existing_socket_info is None:
                     input_mapping[socket_name] = [f"{comp_name}.{socket_name}"]
@@ -281,7 +281,7 @@ class SuperComponent:
         output_mapping = {}
         used_output_names: set[str] = set()
         for comp_name, outputs_dict in pipeline_outputs.items():
-            for socket_name, socket_info in outputs_dict.items():
+            for socket_name in outputs_dict.keys():
                 if socket_name in used_output_names:
                     raise InvalidMappingError(
                         f"Output name conflict: '{socket_name}' is produced by multiple components. "

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -168,8 +168,9 @@ class SuperComponent:
         """
         aggregated_inputs: Dict[str, Dict[str, Any]] = {}
         for wrapper_input_name, pipeline_input_paths in input_mapping.items():
+
             if not isinstance(pipeline_input_paths, list):
-                pipeline_input_paths = [pipeline_input_paths]
+                raise InvalidMappingError(f"Input paths for '{wrapper_input_name}' must be a list of strings.")
 
             for path in pipeline_input_paths:
                 comp_name, socket_name = self._split_component_path(path)
@@ -254,6 +255,9 @@ class SuperComponent:
         """
         resolved_outputs = {}
         for pipeline_output_path, wrapper_output_name in output_mapping.items():
+            if not isinstance(wrapper_output_name, str):
+                raise InvalidMappingError("Output names in output_mapping must be strings.")
+
             comp_name, socket_name = self._split_component_path(pipeline_output_path)
 
             if comp_name not in pipeline_outputs:
@@ -309,9 +313,6 @@ class SuperComponent:
         for wrapper_input_name, pipeline_input_paths in input_mapping.items():
             if wrapper_input_name not in inputs:
                 continue
-
-            if not isinstance(pipeline_input_paths, list):
-                pipeline_input_paths = [pipeline_input_paths]
 
             for socket_path in pipeline_input_paths:
                 comp_name, input_name = self._split_component_path(socket_path)

--- a/haystack_experimental/core/super_component/utils.py
+++ b/haystack_experimental/core/super_component/utils.py
@@ -87,21 +87,6 @@ def _check_non_union_compatibility(type1: T, type2: T, type1_origin: Any, type2_
     return all(_types_are_compatible(t1_arg, t2_arg)
                for t1_arg, t2_arg in zip(type1_args, type2_args))
 
-def _handle_union_type_matches(type1: T, type2: T, type1_origin: T, type2_origin: T) -> bool:
-    """
-    Handles cases where either type is Union.
-    """
-    if type1_origin is Union and type2_origin is not Union:
-        return any(_types_are_compatible(union_arg, type2)
-                   for union_arg in get_args(type1))
-    if type2_origin is Union and type1_origin is not Union:
-        return any(_types_are_compatible(type1, union_arg)
-                   for union_arg in get_args(type2))
-    else:
-        return any(any(_types_are_compatible(arg1, arg2)
-                       for arg2 in get_args(type2))
-                   for arg1 in get_args(type1))
-
 
 def _unwrap_all(t: T, recursive: bool) -> T:
     """

--- a/haystack_experimental/core/super_component/utils.py
+++ b/haystack_experimental/core/super_component/utils.py
@@ -14,7 +14,7 @@ class _delegate_default:
 T = TypeVar("T")
 
 
-def is_compatible(type1: T, type2: T, unwrap_nested: bool = True) -> bool:
+def _is_compatible(type1: T, type2: T, unwrap_nested: bool = True) -> bool:
     """
     Check if two types are compatible (bidirectional/symmetric check).
 

--- a/haystack_experimental/core/super_component/utils.py
+++ b/haystack_experimental/core/super_component/utils.py
@@ -10,7 +10,9 @@ from haystack.core.component.types import HAYSTACK_GREEDY_VARIADIC_ANNOTATION, H
 class _delegate_default:
     """Custom object for delegating filling of default values to the underlying components."""
 
+
 T = TypeVar("T")
+
 
 def is_compatible(type1: T, type2: T, unwrap_nested: bool = True) -> bool:
     """
@@ -99,6 +101,7 @@ def _handle_union_type_matches(type1: T, type2: T, type1_origin: T, type2_origin
         return any(any(_types_are_compatible(arg1, arg2)
                        for arg2 in get_args(type2))
                    for arg1 in get_args(type1))
+
 
 def _unwrap_all(t: T, recursive: bool) -> T:
     """

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -120,11 +120,9 @@ class TestSuperComponent:
         }
 
     def test_auto_output_mapping(self, rag_pipeline):
-        pipeline_outputs = rag_pipeline.outputs()
-        aggregated_outputs, auto_output_mapping = SuperComponent._handle_auto_output_mapping(pipeline_outputs)
-        assert set(aggregated_outputs.keys()) == {"answers", "documents"}
-        assert aggregated_outputs["answers"] == List[GeneratedAnswer]
-        assert aggregated_outputs["documents"] == List[Document]
+        wrapper = SuperComponent(pipeline=rag_pipeline)
+        output_sockets = wrapper.__haystack_output__._sockets_dict
+        assert set(output_sockets.keys()) == {"answers", "documents"}
 
     def test_auto_mapping_sockets(self, rag_pipeline):
         wrapper = SuperComponent(pipeline=rag_pipeline)

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -158,6 +158,13 @@ class TestSuperComponent:
         }
         assert input_sockets["query"].type == str
 
+    def test_run_no_warm_up(self):
+        pipeline = Pipeline()
+        pipeline.add_component("retriever", InMemoryBM25Retriever(document_store=InMemoryDocumentStore()))
+        wrapper = SuperComponent(pipeline=pipeline)
+        with pytest.raises(RuntimeError):
+            wrapper.run(query="What is the capital of France?")
+
     def test_wrapper_serialization(self, document_store):
         """Test serialization and deserialization of pipeline wrapper."""
         pipeline = Pipeline()

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -155,13 +155,6 @@ class TestSuperComponent:
         assert "final_answers" in result
         assert isinstance(result["final_answers"][0], GeneratedAnswer)
 
-    def test_run_no_warm_up(self):
-        pipeline = Pipeline()
-        pipeline.add_component("retriever", InMemoryBM25Retriever(document_store=InMemoryDocumentStore()))
-        wrapper = SuperComponent(pipeline=pipeline)
-        with pytest.raises(RuntimeError):
-            wrapper.run(query="What is the capital of France?")
-
     def test_wrapper_serialization(self, document_store):
         """Test serialization and deserialization of pipeline wrapper."""
         pipeline = Pipeline()

--- a/test/core/super_component/test_utils.py
+++ b/test/core/super_component/test_utils.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from haystack.core.component.types import GreedyVariadic, Variadic
 
-from haystack_experimental.core.super_component.utils import is_compatible
+from haystack_experimental.core.super_component.utils import _is_compatible
 
 
 class TestTypeCompatibility:
@@ -12,27 +12,27 @@ class TestTypeCompatibility:
 
     def test_basic_types(self):
         """Test compatibility of basic Python types."""
-        assert is_compatible(str, str)
-        assert is_compatible(int, int)
-        assert not is_compatible(str, int)
-        assert not is_compatible(float, int)
+        assert _is_compatible(str, str)
+        assert _is_compatible(int, int)
+        assert not _is_compatible(str, int)
+        assert not _is_compatible(float, int)
 
     def test_any_type(self):
         """Test Any type compatibility."""
-        assert is_compatible(int, Any)
-        assert is_compatible(Any, int)
-        assert is_compatible(Any, Any)
-        assert is_compatible(Any, str)
-        assert is_compatible(str, Any)
+        assert _is_compatible(int, Any)
+        assert _is_compatible(Any, int)
+        assert _is_compatible(Any, Any)
+        assert _is_compatible(Any, str)
+        assert _is_compatible(str, Any)
 
     def test_union_types(self):
         """Test Union type compatibility."""
-        assert is_compatible(int, Union[int, str])
-        assert is_compatible(Union[int, str], int)
-        assert is_compatible(Union[int, str], Union[str, int])
-        assert is_compatible(str, Union[int, str])
-        assert not is_compatible(bool, Union[int, str])
-        assert not is_compatible(float, Union[int, str])
+        assert _is_compatible(int, Union[int, str])
+        assert _is_compatible(Union[int, str], int)
+        assert _is_compatible(Union[int, str], Union[str, int])
+        assert _is_compatible(str, Union[int, str])
+        assert not _is_compatible(bool, Union[int, str])
+        assert not _is_compatible(float, Union[int, str])
 
     def test_variadic_type_compatibility(self):
         """Test compatibility with Variadic and GreedyVariadic types."""
@@ -40,30 +40,30 @@ class TestTypeCompatibility:
         variadic_int = Variadic[int]
         greedy_int = GreedyVariadic[int]
 
-        assert is_compatible(variadic_int, int)
-        assert is_compatible(int, variadic_int)
-        assert is_compatible(greedy_int, int)
-        assert is_compatible(int, greedy_int)
+        assert _is_compatible(variadic_int, int)
+        assert _is_compatible(int, variadic_int)
+        assert _is_compatible(greedy_int, int)
+        assert _is_compatible(int, greedy_int)
 
         # List type compatibility
         variadic_list = Variadic[List[int]]
         greedy_list = GreedyVariadic[List[int]]
 
-        assert is_compatible(variadic_list, List[int])
-        assert is_compatible(List[int], variadic_list)
-        assert is_compatible(greedy_list, List[int])
-        assert is_compatible(List[int], greedy_list)
+        assert _is_compatible(variadic_list, List[int])
+        assert _is_compatible(List[int], variadic_list)
+        assert _is_compatible(greedy_list, List[int])
+        assert _is_compatible(List[int], greedy_list)
 
     def test_nested_type_unwrapping(self):
         """Test nested type unwrapping behavior with unwrap_nested parameter."""
         # Test with unwrap_nested=True (default)
         nested_optional = Variadic[List[Optional[int]]]
-        assert is_compatible(nested_optional, List[int])
-        assert is_compatible(List[int], nested_optional)
+        assert _is_compatible(nested_optional, List[int])
+        assert _is_compatible(List[int], nested_optional)
 
         nested_union = Variadic[List[Union[int, None]]]
-        assert is_compatible(nested_union, List[int])
-        assert is_compatible(List[int], nested_union)
+        assert _is_compatible(nested_union, List[int])
+        assert _is_compatible(List[int], nested_union)
 
 
     def test_complex_nested_types(self):
@@ -73,26 +73,26 @@ class TestTypeCompatibility:
         target_type = List[List[int]]
 
         # With unwrap_nested=True
-        assert is_compatible(complex_type, target_type)
-        assert is_compatible(target_type, complex_type)
+        assert _is_compatible(complex_type, target_type)
+        assert _is_compatible(target_type, complex_type)
 
         # With unwrap_nested=False
-        assert not is_compatible(complex_type, target_type, unwrap_nested=False)
-        assert not is_compatible(target_type, complex_type, unwrap_nested=False)
+        assert not _is_compatible(complex_type, target_type, unwrap_nested=False)
+        assert not _is_compatible(target_type, complex_type, unwrap_nested=False)
 
 
     def test_mixed_variadic_types(self):
         """Test mixing Variadic and GreedyVariadic with other type constructs."""
         # Variadic with Union
         var_union = Variadic[Union[int, str]]
-        assert is_compatible(var_union, Union[int, str])
-        assert is_compatible(Union[int, str], var_union)
+        assert _is_compatible(var_union, Union[int, str])
+        assert _is_compatible(Union[int, str], var_union)
 
         # GreedyVariadic with Optional
         greedy_opt = GreedyVariadic[Optional[int]]
-        assert is_compatible(greedy_opt, int)
-        assert is_compatible(int, greedy_opt)
+        assert _is_compatible(greedy_opt, int)
+        assert _is_compatible(int, greedy_opt)
 
         # Nested Variadic and GreedyVariadic
         nested_var = Variadic[List[GreedyVariadic[int]]]
-        assert is_compatible(nested_var, List[int])
+        assert _is_compatible(nested_var, List[int])

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from haystack import Document
@@ -8,7 +12,9 @@ from haystack_experimental.super_components.converters.multi_file_converter impo
 
 @pytest.fixture
 def converter():
-    return MultiFileConverter()
+    converter = MultiFileConverter()
+    converter.warm_up()
+    return converter
 
 
 class TestMultiFileConverter:

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -1,11 +1,10 @@
 import pytest
-from pathlib import Path
-from unittest.mock import Mock, patch
 
 from haystack import Document
 from haystack.dataclasses import ByteStream
 from haystack_experimental.core.super_component import SuperComponent
 from haystack_experimental.super_components.converters.multi_file_converter import MultiFileConverter
+
 
 @pytest.fixture
 def converter():

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -142,6 +142,7 @@ class TestMultiFileConverter:
         assert len(docs) == len(paths)
         assert all(isinstance(doc, Document) for doc in docs)
 
+    @pytest.mark.integration
     def test_run_in_pipeline(self, test_files_path, converter):
         pipeline = Pipeline(max_runs_per_component=1)
         pipeline.add_component("converter", converter)

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -1,7 +1,4 @@
-from typing import Union
-
 import pytest
-from pathlib import Path
 
 from haystack import Document
 from haystack.dataclasses import ByteStream


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Streamlined SuperComponent to reduce duplicate code. 

Some notable changes:
* We always produce an input mapping and output mapping at init time. Either user provided or one created automatically based on pipeline.inputs() and pipeline.outputs()
* Since we always have a mapping now, we were able to reduce the number of runtime functions. 
* Check that the component is warmed up during runtime. This was missing before but now correctly raises a RuntimeError if not warmed up. 
* Updated docstrings

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
* Existing tests
* Expanded tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
