### PR TITLE
fix: Update sede to use new variable names

### DIFF
--- a/haystack_experimental/tools/component_tool.py
+++ b/haystack_experimental/tools/component_tool.py
@@ -200,7 +200,7 @@ class ComponentTool(Tool):
             "name": self.name,
             "description": self.description,
             "parameters": self._unresolved_parameters,
-            "inputs": self.inputs_from_state,
+            "inputs_from_state": self.inputs_from_state,
         }
 
         if self.outputs_to_state is not None:
@@ -210,7 +210,7 @@ class ComponentTool(Tool):
                 if "handler" in config:
                     serialized_config["handler"] = serialize_callable(config["handler"])
                 serialized_outputs[key] = serialized_config
-            serialized["outputs"] = serialized_outputs
+            serialized["outputs_to_state"] = serialized_outputs
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}
 
@@ -223,26 +223,25 @@ class ComponentTool(Tool):
         component_class = import_class_by_name(inner_data["component"]["type"])
         component = component_from_dict(cls=component_class, data=inner_data["component"], name=inner_data["name"])
 
-        if "outputs" in inner_data and inner_data["outputs"]:
+        if "outputs_to_state" in inner_data and inner_data["outputs_to_state"]:
             deserialized_outputs = {}
-            for key, config in inner_data["outputs"].items():
+            for key, config in inner_data["outputs_to_state"].items():
                 deserialized_config = config.copy()
                 if "handler" in config:
                     deserialized_config["handler"] = deserialize_callable(config["handler"])
                 deserialized_outputs[key] = deserialized_config
-            inner_data["outputs"] = deserialized_outputs
-
+            inner_data["outputs_to_state"] = deserialized_outputs
 
         return cls(
             component=component,
             name=inner_data["name"],
             description=inner_data["description"],
             parameters=inner_data.get("parameters", None),
-            inputs_from_state=inner_data.get("inputs", None),
-            outputs_to_state=inner_data.get("outputs", None),
+            inputs_from_state=inner_data.get("inputs_from_state", None),
+            outputs_to_state=inner_data.get("outputs_to_state", None),
         )
 
-    def _create_tool_parameters_schema(self, component: Component, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def _create_tool_parameters_schema(self, component: Component, inputs_from_state: Dict[str, Any]) -> Dict[str, Any]:
         """
         Creates an OpenAI tools schema from a component's run method parameters.
 
@@ -256,7 +255,7 @@ class ComponentTool(Tool):
         param_descriptions = self._get_param_descriptions(component.run)
 
         for input_name, socket in component.__haystack_input__._sockets_dict.items():  # type: ignore[attr-defined]
-            if inputs is not None and input_name in inputs:
+            if inputs_from_state is not None and input_name in inputs_from_state:
                 continue
             input_type = socket.type
             description = param_descriptions.get(input_name, f"Input '{input_name}' for the component.")

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -122,11 +122,13 @@ class DocumentProcessor:
         """
         return {"concatenated": "\n".join(doc.content for doc in documents[:top_k])}
 
+
 def output_handler(old, new):
     """
     Output handler to test serialization.
     """
     return old + new
+
 
 ## Unit tests
 class TestToolComponent:
@@ -159,7 +161,6 @@ class TestToolComponent:
         component = SimpleComponent()
 
         tool = ComponentTool(component=component, inputs_from_state={"text": "text"})
-
 
         assert tool.inputs_from_state == {"text": "text"}
         # Inputs should be excluded from schema generation
@@ -588,8 +589,8 @@ class TestToolComponentInPipelineWithOpenAI:
         assert tool_dict["data"]["name"] == "simple_tool"
         assert tool_dict["data"]["description"] == "A simple tool"
         assert "component" in tool_dict["data"]
-        assert tool_dict["data"]["inputs"] == {"test": "input"}
-        assert tool_dict["data"]["outputs"]["output"]["handler"] == "test.tools.test_component_tool.output_handler"
+        assert tool_dict["data"]["inputs_from_state"] == {"test": "input"}
+        assert tool_dict["data"]["outputs_to_state"]["output"]["handler"] == "test.tools.test_component_tool.output_handler"
 
         # Test deserialization
         new_tool = ComponentTool.from_dict(tool_dict)


### PR DESCRIPTION
### Related Issues

Left over from https://github.com/deepset-ai/haystack-experimental/pull/238

Missed changing the names of the variables in yaml format

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated existing test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
