### PR TITLE
refactor: use ChatGenerator protocol in Agent

### DIFF
--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -157,7 +157,6 @@ class TestAgent:
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
 
-
     def test_run_with_run_streaming(self, openai_mock_chat_completion_chunk, weather_tool):
         chat_generator = OpenAIChatGenerator(
             api_key=Secret.from_token("test-api-key")
@@ -185,7 +184,6 @@ class TestAgent:
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
 
-
     def test_keep_generator_streaming(self, openai_mock_chat_completion_chunk, weather_tool):
         streaming_callback_called = False
 
@@ -212,5 +210,3 @@ class TestAgent:
         assert len(response["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
-
-


### PR DESCRIPTION
### Related Issues

- Use the ChatGenerator protocol added in https://github.com/deepset-ai/haystack/pull/9074

### Proposed Changes:

- Use ChatGenerator protocol instead of limiting to Union of OpenAIChatGenerator and AnthropicChatGenerator
- Update `from_dict` similar to how it was done in LLMMetadataExtractor https://github.com/deepset-ai/haystack/pull/9099

### How did you test it?

existing tests

### Notes for the reviewer

TODO: mypy errror because of this line: https://github.com/deepset-ai/haystack-experimental/pull/253/files#diff-0c4f9946190a2439c7cd7a62deaecc531c220cdd52db40de005cd49b4e658a6dR218
We're passing tools as parameter to a ChatGenerator's run method but the protocol doesn't require every ChatGenerator to accept those. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
