### PR TITLE
fix: `Adaptor` will need `unsafe=True` for the break/resume to work properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
 extra-dependencies = [
   "anthropic-haystack", # Needed for type checking in Agent
   "docstring-parser", # ComponentTool
+  "colorama", # needed for the pipeline checkpoints test - might be removed later
   "markdown-it-py", # MultiFileConverter
   "mdit_plain", # MultiFileConverter
   "nltk", # HierachicalSplitter w/ split_by="sentence"


### PR DESCRIPTION
### Proposed Changes:

- Adaptor will need `unsafe=True` for the break/resume to work properly
- Another edge case of a Joiner having an extra list in serialisation/deserialisation process

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
