### PR TITLE
feat: Add a `super_component` decorator

### DIFF
--- a/haystack_experimental/core/super_component/__init__.py
+++ b/haystack_experimental/core/super_component/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .super_component import SuperComponent
+from .super_component import SuperComponent, super_component
 
-_all_ = ["SuperComponent"]
+__all__ = ["SuperComponent", "super_component"]

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -7,10 +7,11 @@ import inspect
 from types import new_class
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from haystack import component, logging, Pipeline
+from haystack import Pipeline, component, logging
 from haystack.core.pipeline.async_pipeline import AsyncPipeline
 from haystack.core.pipeline.utils import parse_connect_string
 from haystack.core.serialization import default_from_dict, default_to_dict, generate_qualified_class_name
+
 from haystack_experimental.core.super_component.utils import _delegate_default, _is_compatible
 
 logger = logging.getLogger(__name__)

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
-import inspect
 from types import new_class
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
+import inspect
 from types import new_class
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -484,6 +486,10 @@ def super_component(cls: Any):
             input_mapping=getattr(self, "input_mapping", None),
             output_mapping=getattr(self, "output_mapping", None)
         )
+
+    # Preserve original init's signature for IDEs/docs/tools
+    init_wrapper = functools.wraps(original_init)(init_wrapper)
+    init_wrapper.__signature__ = inspect.signature(original_init)
 
     # Function to copy namespace from the original class
     def copy_class_namespace(namespace):

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -2,40 +2,119 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from haystack import Pipeline, component
+from haystack.core.component import component
+from haystack.core.pipeline import Pipeline
+from haystack.core.pipeline.async_pipeline import AsyncPipeline
 from haystack.core.pipeline.utils import parse_connect_string
 from haystack.core.serialization import default_from_dict, default_to_dict, generate_qualified_class_name
-
 from haystack_experimental.core.super_component.utils import _delegate_default, _is_compatible
 
 
-class InvalidMappingError(Exception):
-    """Raised when input or output mappings are invalid or type conflicts are found."""
+class InvalidMappingTypeError(Exception):
+    """Raised when input or output mappings have invalid types or type conflicts."""
+
     pass
 
 
+class InvalidMappingValueError(Exception):
+    """Raised when input or output mappings have invalid values or missing components/sockets."""
+
+    pass
+
+
+class NoInheritMeta(type):
+    """
+    Metaclass for SuperComponent to prevent inheritance of certain attributes.
+    """
+    def __new__(cls, name, bases, dct):
+        cls_obj = super().__new__(cls, name, bases, dct)
+        for attr in getattr(cls_obj, "_no_inherit", []):
+            if hasattr(cls_obj, attr):
+                delattr(cls_obj, attr)
+        return cls_obj
+
+
 @component
-class SuperComponent:
+class SuperComponent(metaclass=NoInheritMeta):
     """
     A class for creating super components that wrap around a Pipeline.
 
     This component allows for remapping of input and output socket names between the wrapped pipeline and the
     SuperComponent's input and output names. This is useful for creating higher-level components that abstract
     away the details of the wrapped pipeline.
+
+    ### Usage example
+
+    ```python
+    from haystack import Pipeline, SuperComponent
+    from haystack.components.generators.chat import OpenAIChatGenerator
+    from haystack.components.builders import ChatPromptBuilder
+    from haystack.components.retrievers import InMemoryBM25Retriever
+    from haystack.dataclasses.chat_message import ChatMessage
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+    from haystack.dataclasses import Document
+
+    document_store = InMemoryDocumentStore()
+    documents = [
+        Document(content="Paris is the capital of France."),
+        Document(content="London is the capital of England."),
+    ]
+    document_store.write_documents(documents)
+
+    prompt_template = [
+        ChatMessage.from_user(
+        '''
+        According to the following documents:
+        {% for document in documents %}
+        {{document.content}}
+        {% endfor %}
+        Answer the given question: {{query}}
+        Answer:
+        '''
+        )
+    ]
+
+    prompt_builder = ChatPromptBuilder(template=prompt_template, required_variables="*")
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", InMemoryBM25Retriever(document_store=document_store))
+    pipeline.add_component("prompt_builder", prompt_builder)
+    pipeline.add_component("llm", OpenAIChatGenerator())
+    pipeline.connect("retriever.documents", "prompt_builder.documents")
+    pipeline.connect("prompt_builder.prompt", "llm.messages")
+
+    # Create a super component with simplified input/output mapping
+    wrapper = SuperComponent(
+        pipeline=pipeline,
+        input_mapping={
+            "query": ["retriever.query", "prompt_builder.query"],
+        },
+        output_mapping={"llm.replies": "replies"}
+    )
+
+    # Run the pipeline with simplified interface
+    result = wrapper.run(query="What is the capital of France?")
+    print(result)
+    {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>,
+     _content=[TextContent(text='The capital of France is Paris.')],...)
+    ```
+
     """
+    # This attribute is used to prevent inheritance of certain attributes
+    _no_inherit = ["to_dict", "from_dict"]
 
     def __init__(
         self,
-        pipeline: Pipeline,
+        pipeline: Union[Pipeline, AsyncPipeline],
         input_mapping: Optional[Dict[str, List[str]]] = None,
         output_mapping: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Creates a SuperComponent with optional input and output mappings.
 
-        :param pipeline: The pipeline instance to be wrapped
+        :param pipeline: The pipeline instance or async pipeline instance to be wrapped
         :param input_mapping: A dictionary mapping component input names to pipeline input socket paths.
             If not provided, a default input mapping will be created based on all pipeline inputs.
         :param output_mapping: A dictionary mapping pipeline output socket paths to component output names.
@@ -46,13 +125,13 @@ class SuperComponent:
         if pipeline is None:
             raise ValueError("Pipeline must be provided to SuperComponent.")
 
-        self.pipeline: Pipeline = pipeline
+        self.pipeline: Union[Pipeline, AsyncPipeline] = pipeline
         self._warmed_up = False
 
         # Determine input types based on pipeline and mapping
         pipeline_inputs = self.pipeline.inputs()
-        resolved_input_mapping = input_mapping if input_mapping is not None else self._create_input_mapping(
-            pipeline_inputs
+        resolved_input_mapping = (
+            input_mapping if input_mapping is not None else self._create_input_mapping(pipeline_inputs)
         )
         self._validate_input_mapping(pipeline_inputs, resolved_input_mapping)
         input_types = self._resolve_input_types_from_mapping(pipeline_inputs, resolved_input_mapping)
@@ -65,8 +144,8 @@ class SuperComponent:
 
         # Set output types based on pipeline and mapping
         pipeline_outputs = self.pipeline.outputs()
-        resolved_output_mapping = output_mapping if output_mapping is not None else self._create_output_mapping(
-            pipeline_outputs
+        resolved_output_mapping = (
+            output_mapping if output_mapping is not None else self._create_output_mapping(pipeline_outputs)
         )
         self._validate_output_mapping(pipeline_outputs, resolved_output_mapping)
         output_types = self._resolve_output_types_from_mapping(pipeline_outputs, resolved_output_mapping)
@@ -87,8 +166,6 @@ class SuperComponent:
         """
         Serializes the SuperComponent into a dictionary.
 
-        Must be overwritten for prebuilt super components that inherit from SuperComponent.
-
         :returns:
             Dictionary with serialized data.
         """
@@ -98,8 +175,6 @@ class SuperComponent:
     def from_dict(cls, data: Dict[str, Any]) -> "SuperComponent":
         """
         Deserializes the SuperComponent from a dictionary.
-
-        Must be overwritten for custom component implementations that inherit from SuperComponent.
 
         :param data: The dictionary to deserialize from.
         :returns:
@@ -127,6 +202,29 @@ class SuperComponent:
         pipeline_outputs = self.pipeline.run(data=pipeline_inputs)
         return self._map_explicit_outputs(pipeline_outputs, self.output_mapping)
 
+    async def run_async(self, **kwargs: Any) -> Dict[str, Any]:
+        """
+        Runs the wrapped pipeline with the provided inputs async.
+
+        Steps:
+        1. Maps the inputs from kwargs to pipeline component inputs
+        2. Runs the pipeline async
+        3. Maps the pipeline outputs to the SuperComponent's outputs
+
+        :param kwargs: Keyword arguments matching the SuperComponent's input names
+        :returns:
+            Dictionary containing the SuperComponent's output values
+        :raises TypeError:
+            If the pipeline is not an AsyncPipeline
+        """
+        if not isinstance(self.pipeline, AsyncPipeline):
+            raise TypeError("Pipeline is not an AsyncPipeline. run_async is not supported.")
+
+        filtered_inputs = {param: value for param, value in kwargs.items() if value != _delegate_default}
+        pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=filtered_inputs)
+        pipeline_outputs = await self.pipeline.run_async(data=pipeline_inputs)
+        return self._map_explicit_outputs(pipeline_outputs, self.output_mapping)
+
     @staticmethod
     def _split_component_path(path: str) -> Tuple[str, str]:
         """
@@ -135,12 +233,12 @@ class SuperComponent:
         :param path: A string in the format "component_name.socket_name".
         :returns:
             A tuple containing (component_name, socket_name).
-        :raises InvalidMappingError:
+        :raises InvalidMappingValueError:
             If the path format is incorrect.
         """
         comp_name, socket_name = parse_connect_string(path)
         if socket_name is None:
-            raise InvalidMappingError(f"Invalid path format: '{path}'. Expected 'component_name.socket_name'.")
+            raise InvalidMappingValueError(f"Invalid path format: '{path}'. Expected 'component_name.socket_name'.")
         return comp_name, socket_name
 
     def _validate_input_mapping(
@@ -151,21 +249,25 @@ class SuperComponent:
 
         :param pipeline_inputs: A dictionary containing pipeline input specifications.
         :param input_mapping: A dictionary mapping wrapper input names to pipeline socket paths.
-        :raises InvalidMappingError:
-            If the input mapping is invalid or contains nonexistent components or sockets.
+        :raises InvalidMappingTypeError:
+            If the input mapping is of invalid type or contains invalid types.
+        :raises InvalidMappingValueError:
+            If the input mapping contains nonexistent components or sockets.
         """
         if not isinstance(input_mapping, dict):
-            raise InvalidMappingError("input_mapping must be a dictionary")
+            raise InvalidMappingTypeError("input_mapping must be a dictionary")
 
         for wrapper_input_name, pipeline_input_paths in input_mapping.items():
             if not isinstance(pipeline_input_paths, list):
-                raise InvalidMappingError(f"Input paths for '{wrapper_input_name}' must be a list of strings.")
+                raise InvalidMappingTypeError(f"Input paths for '{wrapper_input_name}' must be a list of strings.")
             for path in pipeline_input_paths:
                 comp_name, socket_name = self._split_component_path(path)
                 if comp_name not in pipeline_inputs:
-                    raise InvalidMappingError(f"Component '{comp_name}' not found in pipeline inputs.")
+                    raise InvalidMappingValueError(f"Component '{comp_name}' not found in pipeline inputs.")
                 if socket_name not in pipeline_inputs[comp_name]:
-                    raise InvalidMappingError(f"Input socket '{socket_name}' not found in component '{comp_name}'.")
+                    raise InvalidMappingValueError(
+                        f"Input socket '{socket_name}' not found in component '{comp_name}'."
+                    )
 
     def _resolve_input_types_from_mapping(
         self, pipeline_inputs: Dict[str, Dict[str, Any]], input_mapping: Dict[str, List[str]]
@@ -180,7 +282,7 @@ class SuperComponent:
         :param input_mapping: A dictionary mapping SuperComponent inputs to pipeline socket paths.
         :returns:
             A dictionary specifying the resolved input types and their properties.
-        :raises InvalidMappingError:
+        :raises InvalidMappingTypeError:
             If the input mapping contains incompatible types.
         """
         aggregated_inputs: Dict[str, Dict[str, Any]] = {}
@@ -198,7 +300,7 @@ class SuperComponent:
                     continue
 
                 if not _is_compatible(existing_socket_info["type"], socket_info["type"]):
-                    raise InvalidMappingError(
+                    raise InvalidMappingTypeError(
                         f"Type conflict for input '{socket_name}' from component '{comp_name}'. "
                         f"Existing type: {existing_socket_info['type']}, new type: {socket_info['type']}."
                     )
@@ -238,17 +340,19 @@ class SuperComponent:
 
         :param pipeline_outputs: A dictionary containing pipeline output specifications.
         :param output_mapping: A dictionary mapping pipeline socket paths to wrapper output names.
-        :raises InvalidMappingError:
-            If the output mapping is invalid or contains nonexistent components or sockets.
+        :raises InvalidMappingTypeError:
+            If the output mapping is of invalid type or contains invalid types.
+        :raises InvalidMappingValueError:
+            If the output mapping contains nonexistent components or sockets.
         """
         for pipeline_output_path, wrapper_output_name in output_mapping.items():
             if not isinstance(wrapper_output_name, str):
-                raise InvalidMappingError("Output names in output_mapping must be strings.")
+                raise InvalidMappingTypeError("Output names in output_mapping must be strings.")
             comp_name, socket_name = self._split_component_path(pipeline_output_path)
             if comp_name not in pipeline_outputs:
-                raise InvalidMappingError(f"Component '{comp_name}' not found among pipeline outputs.")
+                raise InvalidMappingValueError(f"Component '{comp_name}' not found among pipeline outputs.")
             if socket_name not in pipeline_outputs[comp_name]:
-                raise InvalidMappingError(f"Output socket '{socket_name}' not found in component '{comp_name}'.")
+                raise InvalidMappingValueError(f"Output socket '{socket_name}' not found in component '{comp_name}'.")
 
     def _resolve_output_types_from_mapping(
         self, pipeline_outputs: Dict[str, Dict[str, Any]], output_mapping: Dict[str, str]
@@ -263,14 +367,14 @@ class SuperComponent:
         :param output_mapping: A dictionary mapping pipeline output socket paths to SuperComponent output names.
         :returns:
             A dictionary mapping SuperComponent output names to their resolved types.
-        :raises InvalidMappingError:
+        :raises InvalidMappingValueError:
             If the output mapping contains duplicate output names.
         """
         resolved_outputs = {}
         for pipeline_output_path, wrapper_output_name in output_mapping.items():
             comp_name, socket_name = self._split_component_path(pipeline_output_path)
             if wrapper_output_name in resolved_outputs:
-                raise InvalidMappingError(f"Duplicate output name '{wrapper_output_name}' in output_mapping.")
+                raise InvalidMappingValueError(f"Duplicate output name '{wrapper_output_name}' in output_mapping.")
             resolved_outputs[wrapper_output_name] = pipeline_outputs[comp_name][socket_name]["type"]
         return resolved_outputs
 
@@ -282,13 +386,15 @@ class SuperComponent:
         :param pipeline_outputs: Dictionary of pipeline output specifications
         :returns:
             Dictionary mapping pipeline socket paths to SuperComponent output names
+        :raises InvalidMappingValueError:
+            If there are output name conflicts between components
         """
         output_mapping = {}
         used_output_names: set[str] = set()
         for comp_name, outputs_dict in pipeline_outputs.items():
             for socket_name in outputs_dict.keys():
                 if socket_name in used_output_names:
-                    raise InvalidMappingError(
+                    raise InvalidMappingValueError(
                         f"Output name conflict: '{socket_name}' is produced by multiple components. "
                         "Please provide an output_mapping to resolve this conflict."
                     )
@@ -347,7 +453,51 @@ class SuperComponent:
             self,
             pipeline=serialized_pipeline,
             input_mapping=self._original_input_mapping,
-            output_mapping=self._original_output_mapping
+            output_mapping=self._original_output_mapping,
         )
         serialized["type"] = generate_qualified_class_name(SuperComponent)
         return serialized
+
+
+def super_component(cls):
+    """
+    Decorator that converts a class into a SuperComponent.
+
+    This decorator:
+    1. Makes the class a component (using the @component decorator)
+    2. Verifies the class has required attributes for a SuperComponent
+    3. Automatically handles SuperComponent initialization
+
+    The decorated class should define:
+    - pipeline: A Pipeline or AsyncPipeline instance in the __init__ method
+    - input_mapping: Dictionary mapping component inputs to pipeline inputs (optional)
+    - output_mapping: Dictionary mapping pipeline outputs to component outputs (optional)
+    """
+    # Keep a reference to the original __init__
+    original_init = cls.__init__
+
+    # Define a new __init__ that wraps the original
+    def __init_wrapper__(self, *args, **kwargs):
+        # Call the original __init__ to set up pipeline and mappings
+        original_init(self, *args, **kwargs)
+
+        # Verify required attributes
+        if not hasattr(self, "pipeline"):
+            raise ValueError("Classes decorated with @super_component must define a 'pipeline' attribute")
+
+        # Initialize the SuperComponent with the provided attributes
+        SuperComponent.__init__(
+            self,
+            pipeline=self.pipeline,
+            input_mapping=getattr(self, "input_mapping", None),
+            output_mapping=getattr(self, "output_mapping", None)
+        )
+
+    # Replace the __init__ method
+    cls.__init__ = __init_wrapper__
+
+    # Make the class inherit from SuperComponent
+    cls.__bases__ = (SuperComponent,) + cls.__bases__
+
+    # Apply the component decorator
+    return component(cls)

--- a/haystack_experimental/core/super_component/super_component.py
+++ b/haystack_experimental/core/super_component/super_component.py
@@ -490,7 +490,6 @@ def super_component(cls: Any):
 
     # Preserve original init's signature for IDEs/docs/tools
     init_wrapper = functools.wraps(original_init)(init_wrapper)
-    init_wrapper.__signature__ = inspect.signature(original_init)
 
     # Function to copy namespace from the original class
     def copy_class_namespace(namespace):

--- a/haystack_experimental/super_components/converters/multi_file_converter.py
+++ b/haystack_experimental/super_components/converters/multi_file_converter.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum
-from typing import Any, Dict
 
-from haystack import Pipeline, component, default_from_dict, default_to_dict
+from haystack import Pipeline
 from haystack.components.converters import (
     CSVToDocument,
     DOCXToDocument,
@@ -20,7 +19,7 @@ from haystack.components.converters import (
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.routers import FileTypeRouter
 
-from haystack_experimental.core.super_component import SuperComponent
+from haystack_experimental.core.super_component import super_component
 
 
 class ConverterMimeType(str, Enum):
@@ -35,8 +34,8 @@ class ConverterMimeType(str, Enum):
     XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
-@component
-class MultiFileConverter(SuperComponent):
+@super_component
+class MultiFileConverter:
     """
     A file converter that handles conversion of multiple file types.
 
@@ -60,11 +59,7 @@ class MultiFileConverter(SuperComponent):
     ```
     """
 
-    def __init__(  # noqa: PLR0915
-        self,
-        encoding: str = "utf-8",
-        json_content_key: str = "content",
-    ) -> None:
+    def __init__(self, encoding: str = "utf-8", json_content_key: str = "content") -> None:
         """
         Initialize the MultiFileConverter.
 
@@ -144,26 +139,6 @@ class MultiFileConverter(SuperComponent):
         pp.connect("csv.documents", "joiner.documents")
         pp.connect("xlsx.documents", "joiner.documents")
 
-        output_mapping = {"joiner.documents": "documents", "router.unclassified": "unclassified"}
-        input_mapping = {"sources": ["router.sources"], "meta": ["router.meta"]}
-
-        super(MultiFileConverter, self).__init__(
-            pipeline=pp, output_mapping=output_mapping, input_mapping=input_mapping
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this instance to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            encoding=self.encoding,
-            json_content_key=self.json_content_key,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MultiFileConverter":
-        """
-        Load this instance from a dictionary.
-        """
-        return default_from_dict(cls, data)
+        self.pipeline = pp
+        self.input_mapping = {"sources": ["router.sources"], "meta": ["router.meta"]}
+        self.output_mapping = {"joiner.documents": "documents", "router.unclassified": "unclassified"}

--- a/haystack_experimental/super_components/indexers/sentence_transformers_document_indexer.py
+++ b/haystack_experimental/super_components/indexers/sentence_transformers_document_indexer.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from haystack import Pipeline, component, default_from_dict, default_to_dict
+from haystack import Pipeline, default_from_dict, default_to_dict
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores.types import DocumentStore, DuplicatePolicy
@@ -16,11 +16,11 @@ from haystack.utils import (
 )
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
-from haystack_experimental.core.super_component import SuperComponent
+from haystack_experimental.core.super_component import super_component
 
 
-@component
-class SentenceTransformersDocumentIndexer(SuperComponent):
+@super_component
+class SentenceTransformersDocumentIndexer:
     """
     A document indexer that takes a list of documents, embeds them using SentenceTransformers, and stores them.
 
@@ -41,26 +41,27 @@ class SentenceTransformersDocumentIndexer(SuperComponent):
     ```
     """
 
-    def __init__( # pylint: disable=R0917
-            self,
-            document_store: DocumentStore,
-            model: str = "sentence-transformers/all-mpnet-base-v2",
-            device: Optional[ComponentDevice] = None,
-            token: Optional[Secret] = Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False),
-            prefix: str = "",
-            suffix: str = "",
-            batch_size: int = 32,
-            progress_bar: bool = True,
-            normalize_embeddings: bool = False,
-            meta_fields_to_embed: Optional[List[str]] = None,
-            embedding_separator: str = "\n",
-            trust_remote_code: bool = False,
-            truncate_dim: Optional[int] = None,
-            model_kwargs: Optional[Dict[str, Any]] = None,
-            tokenizer_kwargs: Optional[Dict[str, Any]] = None,
-            config_kwargs: Optional[Dict[str, Any]] = None,
-            precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
-            duplicate_policy: DuplicatePolicy = DuplicatePolicy.OVERWRITE,
+    def __init__(
+        self,
+        *,
+        document_store: DocumentStore,
+        model: str = "sentence-transformers/all-mpnet-base-v2",
+        device: Optional[ComponentDevice] = None,
+        token: Optional[Secret] = Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False),
+        prefix: str = "",
+        suffix: str = "",
+        batch_size: int = 32,
+        progress_bar: bool = True,
+        normalize_embeddings: bool = False,
+        meta_fields_to_embed: Optional[List[str]] = None,
+        embedding_separator: str = "\n",
+        trust_remote_code: bool = False,
+        truncate_dim: Optional[int] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        config_kwargs: Optional[Dict[str, Any]] = None,
+        precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
+        duplicate_policy: DuplicatePolicy = DuplicatePolicy.OVERWRITE,
     ) -> None:
         """
         Initialize the SentenceTransformersDocumentIndexer component.
@@ -136,11 +137,10 @@ class SentenceTransformersDocumentIndexer(SuperComponent):
 
         pipeline.connect("embedder.documents", "writer.documents")
 
-        super(SentenceTransformersDocumentIndexer, self).__init__(
-            pipeline=pipeline,
-            input_mapping={"documents": ["embedder.documents"]},
-            output_mapping={"writer.documents_written": "documents_written"},
-        )
+        # Required attributes for SuperComponent
+        self.pipeline = pipeline
+        self.input_mapping = {"documents": ["embedder.documents"]}
+        self.output_mapping = {"writer.documents_written": "documents_written"}
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -187,8 +187,6 @@ class SentenceTransformersDocumentIndexer(SuperComponent):
 
         # Handle secrets deserialization
         deserialize_secrets_inplace(init_params, keys=["token"])
-
-
 
         # Handle model kwargs deserialization
         if init_params.get("model_kwargs") is not None:

--- a/haystack_experimental/super_components/preprocessors/document_preprocessor.py
+++ b/haystack_experimental/super_components/preprocessors/document_preprocessor.py
@@ -4,16 +4,16 @@
 
 from typing import Any, Callable, Dict, List, Literal, Optional
 
-from haystack import Pipeline, component, default_from_dict, default_to_dict
+from haystack import Pipeline, default_from_dict, default_to_dict
 from haystack.components.preprocessors.document_cleaner import DocumentCleaner
 from haystack.components.preprocessors.document_splitter import DocumentSplitter, Language
 from haystack.utils import deserialize_callable, serialize_callable
 
-from haystack_experimental.core.super_component import SuperComponent
+from haystack_experimental.core.super_component import super_component
 
 
-@component
-class DocumentPreProcessor(SuperComponent):
+@super_component
+class DocumentPreProcessor:
     """
     A SuperComponent that cleans documents and then splits them.
 
@@ -30,8 +30,9 @@ class DocumentPreProcessor(SuperComponent):
     ```
     """
 
-    def __init__( # pylint: disable=R0917
+    def __init__(
         self,
+        *,
         # --- DocumentCleaner arguments ---
         remove_empty_lines: bool = True,
         remove_extra_whitespaces: bool = True,
@@ -124,12 +125,12 @@ class DocumentPreProcessor(SuperComponent):
         )
 
         # Build the Pipeline
-        pp = Pipeline()
-        pp.add_component("cleaner", cleaner)
-        pp.add_component("splitter", splitter)
+        pipeline = Pipeline()
+        pipeline.add_component("cleaner", cleaner)
+        pipeline.add_component("splitter", splitter)
 
         # Connect the cleaner output to splitter
-        pp.connect("cleaner.documents", "splitter.documents")
+        pipeline.connect("cleaner.documents", "splitter.documents")
 
         # Define how pipeline inputs/outputs map to sub-component inputs/outputs
         input_mapping = {
@@ -139,12 +140,10 @@ class DocumentPreProcessor(SuperComponent):
         # The pipeline output "documents" comes from "splitter.documents"
         output_mapping = {"splitter.documents": "documents"}
 
-        # Initialize the SuperComponent
-        super(DocumentPreProcessor, self).__init__(
-            pipeline=pp,
-            input_mapping=input_mapping,
-            output_mapping=output_mapping
-        )
+        # Required attributes for SuperComponent
+        self.pipeline = pipeline
+        self.input_mapping = input_mapping
+        self.output_mapping = output_mapping
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -16,7 +16,7 @@ from haystack.utils.auth import Secret
 from haystack.core.serialization import default_from_dict, default_to_dict
 
 from haystack_experimental import SuperComponent
-from haystack_experimental.core.super_component.super_component import InvalidMappingError
+from haystack_experimental.core.super_component.super_component import InvalidMappingTypeError
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ class TestSuperComponent:
 
     def test_split_component_path_error(self):
         path = "router"
-        with pytest.raises(InvalidMappingError):
+        with pytest.raises(InvalidMappingTypeError):
             SuperComponent._split_component_path(path)
 
     def test_explicit_input_mapping(self, rag_pipeline):

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -16,7 +16,7 @@ from haystack.utils.auth import Secret
 from haystack.core.serialization import default_from_dict, default_to_dict
 
 from haystack_experimental import SuperComponent
-from haystack_experimental.core.super_component.super_component import InvalidMappingTypeError
+from haystack_experimental.core.super_component.super_component import InvalidMappingValueError
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ class TestSuperComponent:
 
     def test_split_component_path_error(self):
         path = "router"
-        with pytest.raises(InvalidMappingTypeError):
+        with pytest.raises(InvalidMappingValueError):
             SuperComponent._split_component_path(path)
 
     def test_explicit_input_mapping(self, rag_pipeline):

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -7,7 +7,6 @@ import pytest
 from haystack import Document, Pipeline
 from haystack.core.pipeline.base import component_to_dict, component_from_dict
 from haystack.dataclasses import ByteStream
-from haystack_experimental.core.super_component import SuperComponent
 from haystack_experimental.super_components.converters.multi_file_converter import MultiFileConverter
 
 
@@ -23,7 +22,6 @@ class TestMultiFileConverter:
         """Test initialization with default parameters"""
         assert converter.encoding == "utf-8"
         assert converter.json_content_key == "content"
-        assert isinstance(converter, SuperComponent)
 
     def test_init_custom_params(self, converter):
         """Test initialization with custom parameters"""

--- a/test/super_components/converters/test_multi_file_converter.py
+++ b/test/super_components/converters/test_multi_file_converter.py
@@ -5,6 +5,7 @@
 import pytest
 
 from haystack import Document, Pipeline
+from haystack.core.pipeline.base import component_to_dict, component_from_dict
 from haystack.dataclasses import ByteStream
 from haystack_experimental.core.super_component import SuperComponent
 from haystack_experimental.super_components.converters.multi_file_converter import MultiFileConverter
@@ -35,7 +36,7 @@ class TestMultiFileConverter:
 
     def test_to_dict(self, converter):
         """Test serialization to dictionary"""
-        data = converter.to_dict()
+        data = component_to_dict(converter, "converter")
         assert data == {
             "type": "haystack_experimental.super_components.converters.multi_file_converter.MultiFileConverter",
             "init_parameters": {
@@ -53,7 +54,7 @@ class TestMultiFileConverter:
                 "json_content_key": "text"
             }
         }
-        conv = MultiFileConverter.from_dict(data)
+        conv = component_from_dict(MultiFileConverter, data, "converter")
         assert conv.encoding == "latin-1"
         assert conv.json_content_key == "text"
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9175

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Creates a base `_SuperComponent` class that contains everything except `to_dict` and `from_dict`. Then in `SuperComponent` we add the default `to_dict` and `from_dict` methods. This should allow users to still directly use `SuperComponent` and allows us to use the `_SuperComponent` base class in the `super_component` decorator where we don't want `to_dict` or `from_dict` to be set. 
- Adds a `super_component` decorator that still preserves the original class information including the signature of the init method. 
- Updated the existing pre-built super components to use the decorator and removed the super().__init__ and to_dict and from_dict where appropriate. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Putting this in experimental for now so we can see how it would effect pre-built super components.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
