### PR TITLE
fix: reverting filename and adding safeguard for tests when filename is not found

### DIFF
--- a/haystack_experimental/core/pipeline/pipeline.py
+++ b/haystack_experimental/core/pipeline/pipeline.py
@@ -543,7 +543,7 @@ class Pipeline(PipelineBase):
         self.debug_path.mkdir(exist_ok=True)
 
         dt = datetime.now()
-        file_name = Path(f"breakpoint_at_{component_name}_{dt.strftime('%Y_%m_%d_%H_%M_%S')}.json")
+        file_name = Path(f"{component_name}_{dt.strftime('%Y_%m_%d_%H_%M_%S')}.json")
         state = {
             "input_data": self._serialize_component_input(self.original_input_data),  # original input data
             "timestamp": dt.isoformat(),

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -296,7 +296,7 @@ class TestPipeline:
             }
         }
         
-        assert Pipeline._validate_resume_state(state)
+        Pipeline._validate_resume_state(state) # should not raise any exception
         
     def test_load_state_loads_valid_state(self, tmp_path):        
         state = {

--- a/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
@@ -75,3 +75,5 @@ class TestPipelineBreakpoints:
                 result = answer_join_pipeline.run(data, resume_state_path=full_path)
                 assert result
                 assert result["answer_joiner"] is not None
+            else:
+                raise Exception("No file found for the component.")

--- a/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
@@ -75,3 +75,5 @@ class TestPipelineBreakpoints:
             if str(f_name).startswith(component):
                 result = branch_joiner_pipeline.run(data, resume_state_path=full_path)
                 assert result
+            else:
+                raise Exception("No file found for the component.")

--- a/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
@@ -84,3 +84,5 @@ class TestPipelineBreakpoints:
             if str(f_name).startswith(component):
                 result = list_joiner_pipeline.run(data, resume_state_path=full_path)
                 assert result
+            else:
+                raise Exception("No file found for the component.")

--- a/test/core/pipeline/test_pipeline_breakpoints_loops.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_loops.py
@@ -157,7 +157,6 @@ class TestPipelineBreakpointsLoops:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 result = validation_loop_pipeline.run(data={}, resume_state_path=full_path)
-
                 # Verify the result contains valid output
                 if "output_validator" in result and "valid_replies" in result["output_validator"]:
                     valid_reply = result["output_validator"]["valid_replies"][0].text
@@ -166,3 +165,5 @@ class TestPipelineBreakpointsLoops:
                     assert "cities" in valid_json
                     cities_data = CitiesData.model_validate(valid_json)
                     assert len(cities_data.cities) == 3
+            else:
+                raise Exception("No file found for the component.")

--- a/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
@@ -157,3 +157,5 @@ class TestPipelineBreakpoints:
                 result = hybrid_rag_pipeline.run(data, breakpoints=None, resume_state_path=full_path)
                 assert 'answer_builder' in result
                 assert result['answer_builder']
+            else:
+                raise Exception("Breakpoint not found in output files.")

--- a/test/core/pipeline/test_pipeline_breakpoints_string_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_string_joiner.py
@@ -65,3 +65,5 @@ class TestPipelineBreakpoints:
             if str(f_name).startswith(component):
                 result = string_joiner_pipeline.run(data, resume_state_path=full_path)
                 assert result
+            else:
+                raise Exception("No file found for the component.")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
