### PR TITLE
Revert internal call to pipeline_load state

### DIFF
--- a/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
@@ -74,7 +74,8 @@ class TestPipelineBreakpoints:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = answer_join_pipeline.run(data, breakpoints=None, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = answer_join_pipeline.run(data, breakpoints=None, resume_state=resume_state)
                 assert result['answer_joiner']
                 break
         if not file_found:

--- a/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
@@ -75,7 +75,8 @@ class TestPipelineBreakpoints:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = branch_joiner_pipeline.run(data, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = branch_joiner_pipeline.run(data, resume_state=resume_state)
                 assert result['validator']
                 break
         if not file_found:

--- a/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
@@ -84,7 +84,8 @@ class TestPipelineBreakpoints:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = list_joiner_pipeline.run(data, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = list_joiner_pipeline.run(data, resume_state=resume_state)
                 assert result['list_joiner']
         if not file_found:
             raise ValueError("No files found for {component} in {output_directory}.")

--- a/test/core/pipeline/test_pipeline_breakpoints_loops.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_loops.py
@@ -162,7 +162,8 @@ class TestPipelineBreakpointsLoops:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = validation_loop_pipeline.run(data={}, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = validation_loop_pipeline.run(data={}, resume_state=resume_state)
                 # Verify the result contains valid output
                 if "output_validator" in result and "valid_replies" in result["output_validator"]:
                     valid_reply = result["output_validator"]["valid_replies"][0].text

--- a/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
@@ -141,7 +141,8 @@ class TestPipelineBreakpoints:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = hybrid_rag_pipeline.run(data, breakpoints=None, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = hybrid_rag_pipeline.run(data, breakpoints=None, resume_state=resume_state)
                 assert 'answer_builder' in result
                 assert result['answer_builder']
                 break

--- a/test/core/pipeline/test_pipeline_breakpoints_string_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_string_joiner.py
@@ -65,7 +65,8 @@ class TestPipelineBreakpoints:
             f_name = str(full_path).split("/")[-1]
             if str(f_name).startswith(component):
                 file_found = True
-                result = string_joiner_pipeline.run(data, resume_state_path=full_path)
+                resume_state = Pipeline.load_state(full_path)
+                result = string_joiner_pipeline.run(data, resume_state=resume_state)
                 assert result
         if not file_found:
             raise ValueError("No files found for {component} in {output_directory}.")


### PR DESCRIPTION
Instead of passing the state file path, we allow the user to call `load_state` and pass the state to `run` method to resume the pipeline. This was requested by Thomas.