### PR TITLE
fix: preserve initialization parameters in debug state when run params are not supplied 

### DIFF
--- a/haystack_experimental/core/pipeline/pipeline.py
+++ b/haystack_experimental/core/pipeline/pipeline.py
@@ -122,6 +122,7 @@ class Pipeline(PipelineBase):
             span.set_content_tag("haystack.component.input", deepcopy(component_inputs))
             logger.info("Running component {component_name}", component_name=component_name)
             try:
+                print(f"Running component {component_name} with inputs: {component_inputs}")
                 component_output = instance.run(**component_inputs)
             except Exception as error:
                 raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error

--- a/haystack_experimental/core/pipeline/pipeline.py
+++ b/haystack_experimental/core/pipeline/pipeline.py
@@ -54,6 +54,7 @@ class Pipeline(PipelineBase):
         """
         instance: Component = component["instance"]
         component_name = self.get_component_name(instance)
+
         component_inputs = self._consume_component_inputs(
             component_name=component_name, component=component, inputs=inputs
         )
@@ -83,10 +84,14 @@ class Pipeline(PipelineBase):
             for key, value in component_inputs.items():
                 component_inputs[key] = Pipeline._deserialize_component_input(value)
 
-        # add component_inputs to inputs
-        breakpoint_inputs = deepcopy(inputs)
-        breakpoint_inputs[component_name] = Pipeline._remove_unserializable_data(component_inputs)
         if breakpoints and not self.resume_state:
+            # add component_inputs to inputs
+            breakpoint_inputs = deepcopy(inputs)
+            # we deepcopy the component_inputs to avoid modifying the original inputs
+            breakpoint_inputs[component_name] = deepcopy(Pipeline._remove_unserializable_data(component_inputs))
+            if hasattr(component["instance"], "to_dict"):
+                params = component["instance"].to_dict()
+                breakpoint_inputs[component_name]["init_parameters"] = params["init_parameters"]
             self._check_breakpoints(breakpoints, component_name, component_visits, breakpoint_inputs)
 
         with tracing.tracer.trace(
@@ -476,7 +481,6 @@ class Pipeline(PipelineBase):
         """
         value = Pipeline._remove_unserializable_data(value)
         value = Pipeline.transform_json_structure(value)
-
         if hasattr(value, "to_dict") and callable(getattr(value, "to_dict")):
             serialized_value = value.to_dict()
             serialized_value["_type"] = value.__class__.__name__
@@ -566,6 +570,15 @@ class Pipeline(PipelineBase):
 
         dt = datetime.now()
         file_name = Path(f"{component_name}_{dt.strftime('%Y_%m_%d_%H_%M_%S')}.json")
+        # we store init_parameters for the component with breakpoint in the saved state
+        # this is helpful for debugging or manually updating the state
+        for value in inputs.values():
+            if "init_parameters" in value.keys():
+                init_params = value.pop("init_parameters")
+                for k, v in value.items():
+                    if k in init_params.keys() and v is None:
+                        value[k] = init_params[k]
+
         state = {
             "input_data": self._serialize_component_input(self.original_input_data),  # original input data
             "timestamp": dt.isoformat(),

--- a/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
@@ -38,7 +38,6 @@ class TestPipelineBreakpoints:
 
             # Create a mock for the OpenAIChatGenerator
             @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-api-key'})
-
             def create_mock_generator(model_name):
                 generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_env_var("OPENAI_API_KEY"))
 

--- a/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_answer_joiner.py
@@ -11,6 +11,8 @@ from haystack.utils.auth import Secret
 from haystack_experimental.core.errors import PipelineBreakpointException
 from haystack_experimental.core.pipeline.pipeline import Pipeline
 from test.conftest import load_and_resume_pipeline_state
+from unittest.mock import patch
+
 
 
 class TestPipelineBreakpoints:
@@ -31,30 +33,32 @@ class TestPipelineBreakpoints:
                 "completion_tokens": 40,
                 "total_tokens": 97
             }
-            
+
             mock_chat_completion_create.return_value = mock_completion
-            
+
             # Create a mock for the OpenAIChatGenerator
+            @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-api-key'})
+
             def create_mock_generator(model_name):
-                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_token("test-api-key"))
-                
+                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_env_var("OPENAI_API_KEY"))
+
                 # Mock the run method
                 def mock_run(messages, streaming_callback=None, generation_kwargs=None, tools=None, tools_strict=None):
                     if "gpt-4" in model_name:
                         content = "Natural Language Processing (NLP) is a field of AI focused on enabling computers to understand, interpret, and generate human language."
                     else:
                         content = "NLP is a branch of AI that helps machines understand and process human language."
-                    
+
                     return {
                         "replies": [ChatMessage.from_assistant(content)],
                         "meta": {"model": model_name, "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97}}
                     }
-                
+
                 # Replace the run method with our mock
                 generator.run = mock_run
-                
+
                 return generator
-            
+
             yield create_mock_generator
 
     @pytest.fixture

--- a/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_branch_joiner.py
@@ -13,6 +13,7 @@ from haystack.dataclasses import ChatMessage
 from haystack.utils.auth import Secret
 from haystack_experimental.core.errors import PipelineBreakpointException
 from haystack_experimental.core.pipeline.pipeline import Pipeline
+from unittest.mock import patch
 
 class TestPipelineBreakpoints:
 
@@ -36,27 +37,28 @@ class TestPipelineBreakpoints:
                 "completion_tokens": 40,
                 "total_tokens": 97
             }
-            
+
             mock_chat_completion_create.return_value = mock_completion
-            
+
             # Create a mock for the OpenAIChatGenerator
+            @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-api-key'})
             def create_mock_generator(model_name):
-                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_token("test-api-key"))
-                
+                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_env_var("OPENAI_API_KEY"))
+
                 # Mock the run method
                 def mock_run(messages, streaming_callback=None, generation_kwargs=None, tools=None, tools_strict=None):
                     content = '{"first_name": "Peter", "last_name": "Parker", "nationality": "American"}'
-                    
+
                     return {
                         "replies": [ChatMessage.from_assistant(content)],
                         "meta": {"model": model_name, "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97}}
                     }
-                
+
                 # Replace the run method with our mock
                 generator.run = mock_run
-                
+
                 return generator
-            
+
             yield create_mock_generator
 
     @pytest.fixture
@@ -121,4 +123,3 @@ class TestPipelineBreakpoints:
         if not file_found:
             msg = f"No files found for {component} in {output_directory}."
             raise ValueError(msg)
-

--- a/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_list_joiner.py
@@ -12,7 +12,7 @@ from haystack.utils.auth import Secret
 from haystack_experimental.core.errors import PipelineBreakpointException
 from haystack_experimental.core.pipeline.pipeline import Pipeline
 from test.conftest import load_and_resume_pipeline_state
-
+from unittest.mock import patch
 
 class TestPipelineBreakpoints:
 
@@ -36,13 +36,14 @@ class TestPipelineBreakpoints:
                 "completion_tokens": 40,
                 "total_tokens": 97
             }
-            
+
             mock_chat_completion_create.return_value = mock_completion
-            
+
             # Create a mock for the OpenAIChatGenerator
+            @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-api-key'})
             def create_mock_generator(model_name):
-                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_token("test-api-key"))
-                
+                generator = OpenAIChatGenerator(model=model_name, api_key=Secret.from_env_var("OPENAI_API_KEY"))
+
                 # Mock the run method
                 def mock_run(messages, streaming_callback=None, generation_kwargs=None, tools=None, tools_strict=None):
                     # Check if this is a feedback request or a regular query
@@ -50,17 +51,17 @@ class TestPipelineBreakpoints:
                         content = "Score: 8/10. The answer is concise and accurate, providing a good overview of nuclear physics."
                     else:
                         content = "Nuclear physics is the study of atomic nuclei, their constituents, and their interactions."
-                    
+
                     return {
                         "replies": [ChatMessage.from_assistant(content)],
                         "meta": {"model": model_name, "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97}}
                     }
-                
+
                 # Replace the run method with our mock
                 generator.run = mock_run
-                
+
                 return generator
-            
+
             yield create_mock_generator
 
     @pytest.fixture


### PR DESCRIPTION
### Related Issues

- fixes #284 

### Proposed Changes:
Added functionality to preserve initialization parameters in debug state. When parameters are defined in component initialization but null in the run method, we now automatically restore the original init values in the saved pipeline state for improved debugging.

