### PR TITLE
feat: add convenience class methods to `Imagecontent`

### DIFF
--- a/haystack_experimental/components/image_converters/file_to_image.py
+++ b/haystack_experimental/components/image_converters/file_to_image.py
@@ -126,7 +126,6 @@ class ImageFileToImageContent:
                 )
                 continue
 
-
             merged_metadata = {**bytestream.meta, **metadata}
             image_content = ImageContent(
                 base64_image=base64_image, mime_type=inferred_mime_type, meta=merged_metadata, detail=resolved_detail

--- a/haystack_experimental/components/image_converters/file_to_image.py
+++ b/haystack_experimental/components/image_converters/file_to_image.py
@@ -126,8 +126,6 @@ class ImageFileToImageContent:
                 )
                 continue
 
-            print(f"metadata: {metadata}")
-            print(f"bytestream.meta: {bytestream.meta}")
 
             merged_metadata = {**bytestream.meta, **metadata}
             image_content = ImageContent(

--- a/haystack_experimental/components/image_converters/file_to_image.py
+++ b/haystack_experimental/components/image_converters/file_to_image.py
@@ -69,11 +69,11 @@ class ImageFileToImageContent:
         :param sources:
             List of file paths or ByteStream objects to convert.
         :param meta:
-            Optional metadata to attach to the documents.
+            Optional metadata to attach to the ImageContent objects.
             This value can be a list of dictionaries or a single dictionary.
-            If it's a single dictionary, its content is added to the metadata of all produced documents.
+            If it's a single dictionary, its content is added to the metadata of all produced ImageContent objects.
             If it's a list, its length must match the number of sources as they're zipped together.
-            For ByteStream objects, their `meta` is added to the output documents.
+            For ByteStream objects, their `meta` is added to the output ImageContent objects.
         :param detail:
             Optional detail level of the image (only supported by OpenAI). One of "auto", "high", or "low".
             This will be passed to the created ImageContent objects.

--- a/haystack_experimental/components/image_converters/file_to_image.py
+++ b/haystack_experimental/components/image_converters/file_to_image.py
@@ -126,6 +126,9 @@ class ImageFileToImageContent:
                 )
                 continue
 
+            print(f"metadata: {metadata}")
+            print(f"bytestream.meta: {bytestream.meta}")
+
             merged_metadata = {**bytestream.meta, **metadata}
             image_content = ImageContent(
                 base64_image=base64_image, mime_type=inferred_mime_type, meta=merged_metadata, detail=resolved_detail

--- a/haystack_experimental/components/image_converters/pdf_to_image.py
+++ b/haystack_experimental/components/image_converters/pdf_to_image.py
@@ -67,11 +67,11 @@ class PDFToImageContent:
         :param sources:
             List of file paths or ByteStream objects to convert.
         :param meta:
-            Optional metadata to attach to the documents.
+            Optional metadata to attach to the ImageContent objects.
             This value can be a list of dictionaries or a single dictionary.
-            If it's a single dictionary, its content is added to the metadata of all produced documents.
+            If it's a single dictionary, its content is added to the metadata of all produced ImageContent objects.
             If it's a list, its length must match the number of sources as they're zipped together.
-            For ByteStream objects, their `meta` is added to the output documents.
+            For ByteStream objects, their `meta` is added to the output ImageContent objects.
         :param detail:
             Optional detail level of the image (only supported by OpenAI). One of "auto", "high", or "low".
             This will be passed to the created ImageContent objects.

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -127,7 +127,9 @@ class ImageContent:
         meta: Optional[Dict[str, Any]] = None,
     ) -> "ImageContent":
         """
-        Create an ImageContent object from a URL.
+        Create an ImageContent object from a URL. The image is downloaded and converted to a base64 string.
+
+        For PDF to ImageContent conversion, use the `PDFToImageContent` component.
 
         :param url:
             The URL of the image.

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -83,7 +83,7 @@ class ImageContent:
         Create an ImageContent object from a file path.
 
         It exposes similar functionality as the `ImageFileToImageContent` component. For PDF to ImageContent conversion,
-        use the `ImageFileToImageContent` component.
+        use the `PDFToImageContent` component.
 
         :param file_path:
             The path to the image file.

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -19,7 +19,7 @@ from haystack_experimental.components.image_converters.image_utils import MIME_T
 
 logger = logging.getLogger(__name__)
 
-IMAGE_MIME_TYPES = [key for key in MIME_TO_FORMAT.keys() if key != "application/pdf"]
+IMAGE_MIME_TYPES = {key for key in MIME_TO_FORMAT.keys() if key != "application/pdf"}
 
 
 @dataclass

--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -129,9 +129,6 @@ class ImageContent:
         """
         Create an ImageContent object from a URL.
 
-        It exposes similar functionality as the `ImageFileToImageContent` component. For PDF to ImageContent conversion,
-        use the `ImageFileToImageContent` component.
-
         :param url:
             The URL of the image.
         :param retry_attempts:

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import base64
 import json
-
+import logging
 import pytest
-
+from unittest.mock import Mock, patch
+import httpx
 from haystack_experimental.dataclasses.chat_message import (
     ChatMessage,
     ChatRole,
@@ -515,3 +516,91 @@ def test_to_openai_dict_format_invalid():
     message = ChatMessage.from_tool(tool_result="result", origin=tool_call_null_id)
     with pytest.raises(ValueError):
         message.to_openai_dict_format()
+
+def test_image_content_from_file_path(test_files_path):
+    image_content = ImageContent.from_file_path(
+        file_path=test_files_path / "images" / "apple.jpg",
+        size=(100, 100),
+        detail="high",
+        meta={"test": "test"},
+    )
+
+    assert image_content.base64_image is not None
+    assert image_content.mime_type == "image/jpeg"
+    assert image_content.detail == "high"
+    assert image_content.meta == {"test": "test", "file_path": str(test_files_path / "images" / "apple.jpg")}
+
+def test_image_content_from_file_path_with_mime_type(test_files_path):
+    image_content = ImageContent.from_file_path(
+        file_path=test_files_path / "images" / "apple.jpg",
+        detail="high",
+        meta={"test": "test"},
+        mime_type="image/png",  # in case the mime type is provided, the file extension is ignored
+    )
+
+    assert image_content.base64_image is not None
+    assert image_content.mime_type == "image/png"
+    assert image_content.detail == "high"
+    assert image_content.meta == {"test": "test", "file_path": str(test_files_path / "images" / "apple.jpg")}
+
+def test_image_content_from_file_path_non_existing(test_files_path, caplog):
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(IndexError):
+        ImageContent.from_file_path(
+            file_path=test_files_path / "images" / "non_existing.jpg",
+        )
+    assert "No such file" in caplog.text
+
+def test_image_content_from_url(test_files_path):
+
+    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        mock_response = Mock(
+            status_code=200,
+            content=open(test_files_path / "images" / "apple.jpg", "rb").read(),
+            headers={"Content-Type": "image/jpeg"},
+        )
+        mock_get.return_value = mock_response
+
+        image_content = ImageContent.from_url(
+            url="https://example.com/apple.jpg",
+            size=(100, 100),
+            detail="high",
+            meta={"test": "test"},
+        )
+
+        assert image_content.base64_image is not None
+        assert image_content.mime_type == "image/jpeg"
+        assert image_content.detail == "high"
+        assert image_content.meta == {"test": "test", "url": "https://example.com/apple.jpg", "content_type": "image/jpeg"}
+
+
+def test_image_content_from_url_with_mime_type(test_files_path):
+    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        mock_response = Mock(
+            status_code=200,
+            content=open(test_files_path / "images" / "apple.jpg", "rb").read(),
+            headers={"Content-Type": "image/jpeg"},
+        )
+        mock_get.return_value = mock_response
+
+        image_content = ImageContent.from_url(
+            url="https://example.com/apple.jpg",
+            mime_type="image/png",  # in case the mime type is provided, the URL content type is ignored
+        )
+
+        assert image_content.base64_image is not None
+        assert image_content.mime_type == "image/png"
+        assert image_content.meta == {"url": "https://example.com/apple.jpg", "content_type": "image/jpeg"}
+
+def test_image_content_from_url_bad_request(test_files_path):
+
+    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        mock_get.side_effect = httpx.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())       
+
+        with pytest.raises(httpx.HTTPStatusError):
+            ImageContent.from_url(
+                url="https://non_existent_website_dot.com/image.jpg",
+                retry_attempts=0,
+                timeout=1,
+            )

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: D103
-
 import base64
 import json
 import logging

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -1,12 +1,17 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# ruff: noqa: D103
+
 import base64
 import json
 import logging
-import pytest
 from unittest.mock import Mock, patch
+
 import httpx
+import pytest
+
 from haystack_experimental.dataclasses.chat_message import (
     ChatMessage,
     ChatRole,
@@ -464,8 +469,12 @@ def test_to_openai_dict_format_user_message():
     assert message.to_openai_dict_format() == {"role": "user", "content": "I have a question"}
 
 def test_to_openai_dict_format_multimodal_user_message():
-    message = ChatMessage.from_user(content_parts=[TextContent("I have a question"), ImageContent(base64_image="base64_string")])
-    assert message.to_openai_dict_format() == {"role": "user", "content": [{"type": "text", "text": "I have a question"}, {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,base64_string"}}]}    
+    message = ChatMessage.from_user(content_parts=[TextContent("I have a question"),
+                                                   ImageContent(base64_image="base64_string")])
+    assert message.to_openai_dict_format() == {"role": "user",
+                                               "content": [{"type": "text", "text": "I have a question"},
+                                                            {"type": "image_url", "image_url":
+                                                            {"url": "data:image/jpeg;base64,base64_string"}}]}
 
 def test_to_openai_dict_format_assistant_message():
     message = ChatMessage.from_assistant(text="I have an answer", meta={"finish_reason": "stop"})
@@ -525,23 +534,22 @@ def test_image_content_from_file_path(test_files_path):
         meta={"test": "test"},
     )
 
-    assert image_content.base64_image is not None
+    assert isinstance(image_content.base64_image, str)
     assert image_content.mime_type == "image/jpeg"
     assert image_content.detail == "high"
     assert image_content.meta == {"test": "test", "file_path": str(test_files_path / "images" / "apple.jpg")}
 
-def test_image_content_from_file_path_with_mime_type(test_files_path):
-    image_content = ImageContent.from_file_path(
-        file_path=test_files_path / "images" / "apple.jpg",
-        detail="high",
-        meta={"test": "test"},
-        mime_type="image/png",  # in case the mime type is provided, the file extension is ignored
-    )
+def test_image_content_from_file_path_pdf_unsupported(test_files_path, caplog):
+    with pytest.raises(IndexError):
+        ImageContent.from_file_path(
+            file_path=test_files_path / "pdf" / "sample_pdf_1.pdf",
+            size=(100, 100),
+            detail="high",
+            meta={"test": "test"},
+        )
 
-    assert image_content.base64_image is not None
-    assert image_content.mime_type == "image/png"
-    assert image_content.detail == "high"
-    assert image_content.meta == {"test": "test", "file_path": str(test_files_path / "images" / "apple.jpg")}
+    assert "Could not convert file" in caplog.text
+    assert "PDF" in caplog.text
 
 def test_image_content_from_file_path_non_existing(test_files_path, caplog):
     caplog.set_level(logging.WARNING)
@@ -569,34 +577,15 @@ def test_image_content_from_url(test_files_path):
             meta={"test": "test"},
         )
 
-        assert image_content.base64_image is not None
-        assert image_content.mime_type == "image/jpeg"
-        assert image_content.detail == "high"
-        assert image_content.meta == {"test": "test", "url": "https://example.com/apple.jpg", "content_type": "image/jpeg"}
+    assert isinstance(image_content.base64_image, str)
+    assert image_content.mime_type == "image/jpeg"
+    assert image_content.detail == "high"
+    assert image_content.meta == {"test": "test", "url": "https://example.com/apple.jpg", "content_type": "image/jpeg"}
 
-
-def test_image_content_from_url_with_mime_type(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
-        mock_response = Mock(
-            status_code=200,
-            content=open(test_files_path / "images" / "apple.jpg", "rb").read(),
-            headers={"Content-Type": "image/jpeg"},
-        )
-        mock_get.return_value = mock_response
-
-        image_content = ImageContent.from_url(
-            url="https://example.com/apple.jpg",
-            mime_type="image/png",  # in case the mime type is provided, the URL content type is ignored
-        )
-
-        assert image_content.base64_image is not None
-        assert image_content.mime_type == "image/png"
-        assert image_content.meta == {"url": "https://example.com/apple.jpg", "content_type": "image/jpeg"}
-
-def test_image_content_from_url_bad_request(test_files_path):
+def test_image_content_from_url_bad_request():
 
     with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
-        mock_get.side_effect = httpx.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())       
+        mock_get.side_effect = httpx.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())
 
         with pytest.raises(httpx.HTTPStatusError):
             ImageContent.from_url(
@@ -604,3 +593,48 @@ def test_image_content_from_url_bad_request(test_files_path):
                 retry_attempts=0,
                 timeout=1,
             )
+
+def test_image_content_from_url_wrong_mime_type_text():
+
+    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        mock_response = Mock(
+            status_code=200,
+            text="a text",
+            headers={"Content-Type": "text/plain"},
+        )
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ValueError):
+            ImageContent.from_url(
+                url="https://example.com/text.txt",
+                size=(100, 100),
+                detail="high",
+                meta={"test": "test"},
+            )
+
+def test_image_content_from_url_wrong_mime_type_pdf(test_files_path):
+    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        mock_response = Mock(
+            status_code=200,
+            content=open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb").read(),
+            headers={"Content-Type": "application/pdf"},
+        )
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ValueError):
+            ImageContent.from_url(
+                url="https://example.com/sample_pdf_1.pdf",
+                size=(100, 100),
+                detail="high",
+                meta={"test": "test"},
+            )
+
+@pytest.mark.integration
+def test_image_content_from_url_wrong_mime_type():
+    with pytest.raises(ValueError):
+        ImageContent.from_url(
+            url="https://example.com",
+            size=(100, 100),
+            detail="high",
+            meta={"test": "test"},
+        )


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack/issues/9258

### Proposed Changes:
- add `ImageContent.from_file_path` class method
- add `ImageContent.from_url` class method

### How did you test it?
CI; several new unit tests

### Notes for the reviewer
- I decided to reuse the existing components in these class methods (`ImageFileToImageContent` and `LinkContentFetcher`) to avoid duplication and reduce maintenance efforts
- One aspect I want to discuss is MIME type: in the current implementation of these class methods, the user is free to set it and in this case we don't infer it from file path/URL content type. To keep the code simple, an alternative would be to remove this parameter entirely and always infer the MIME type. Given a file path or URL, MIME type inference is generally reliable. What do you think?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
