### PR TITLE
feat: add Jinja2 ChatMessage extension

### DIFF
--- a/haystack_experimental/dataclasses/chat_message.py
+++ b/haystack_experimental/dataclasses/chat_message.py
@@ -42,7 +42,7 @@ def _deserialize_content_part(part: Dict[str, Any]) -> ChatMessageContentT:
     if "image" in part:
         return ImageContent(**part["image"])
     raise ValueError(f"Unsupported part in serialized ChatMessage: `{part}`")
-    
+
 
 
 def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatMessageContentT]:
@@ -143,8 +143,13 @@ class ChatMessage(HaystackChatMessage):
             if not any(isinstance(el, TextContent) for el in content):
                 raise ValueError("The user message must contain at least one textual part.")
 
+            unsupported_parts = [el for el in content if not isinstance(el, (ImageContent, TextContent))]
+            if unsupported_parts:
+                raise ValueError(f"The user message must contain only text or image parts."
+                                 f"Unsupported parts: {unsupported_parts}")
+
         return cls(_role=ChatRole.USER, _content=content, _meta=meta or {}, _name=name)
-    
+
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/haystack_experimental/utils/__init__.py
+++ b/haystack_experimental/utils/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/haystack_experimental/utils/jinja_chat_extension.py
+++ b/haystack_experimental/utils/jinja_chat_extension.py
@@ -87,6 +87,8 @@ class ChatMessageExtension(Extension):
             parser.stream.skip()
             parser.stream.expect("assign")
             name_expr = parser.parse_expression()
+            if not isinstance(name_expr.value, str):
+                raise TemplateSyntaxError("name must be a string", lineno)
 
         # Parse optional meta attribute
         meta_expr = None
@@ -94,6 +96,8 @@ class ChatMessageExtension(Extension):
             parser.stream.skip()
             parser.stream.expect("assign")
             meta_expr = parser.parse_expression()
+            if not isinstance(meta_expr, nodes.Dict):
+                raise TemplateSyntaxError("meta must be a dictionary", lineno)
 
         # Parse message body
         body = parser.parse_statements(("name:endmessage",), drop_needle=True)

--- a/haystack_experimental/utils/jinja_chat_extension.py
+++ b/haystack_experimental/utils/jinja_chat_extension.py
@@ -258,7 +258,7 @@ class ChatMessageExtension(Extension):
 
 def for_template(value: ChatMessageContentT) -> str:
     """
-    Convert an ChatMessageContentT object into JSON string wrapped in special XML content tags.
+    Jinja filter to convert an ChatMessageContentT object into JSON string wrapped in special XML content tags.
 
     :param value: The ChatMessageContentT object to convert
     :return: A JSON string wrapped in special XML content tags

--- a/haystack_experimental/utils/jinja_chat_extension.py
+++ b/haystack_experimental/utils/jinja_chat_extension.py
@@ -42,14 +42,14 @@ class ChatMessageExtension(Extension):
     {% message role="user" %}
     Hello! I am {{user_name}}. Please describe the images.
     {% for image in images %}
-    {{ image | for_template }}
+    {{ image | templatize_part }}
     {% endfor %}
     {% endmessage %}
 
     ### How it works
     1. The {% message %} tag is used to define a chat message.
     2. The message can contain text and other structured content parts.
-    3. To include a structured content part in the message, the `| for_template` filter is used.
+    3. To include a structured content part in the message, the `| templatize_part` filter is used.
        The filter serializes the content part into a JSON string and wraps it in a `<haystack_content_part>` tag.
     4. The `_build_chat_message_json` method of the extension parses the message content parts,
        converts them into a ChatMessage object and serializes it to a JSON string.
@@ -256,7 +256,7 @@ class ChatMessageExtension(Extension):
 
         raise ValueError(f"Unsupported role: {role}")
 
-def for_template(value: ChatMessageContentT) -> str:
+def templatize_part(value: ChatMessageContentT) -> str:
     """
     Jinja filter to convert an ChatMessageContentT object into JSON string wrapped in special XML content tags.
 

--- a/haystack_experimental/utils/jinja_chat_extension.py
+++ b/haystack_experimental/utils/jinja_chat_extension.py
@@ -44,7 +44,7 @@ class ChatMessageExtension(Extension):
     {% endfor %}
     {% endmessage %}
 
-    ## How it works
+    ### How it works
     1. The {% message %} tag is used to define a chat message.
     2. The message can contain text and other structured content parts.
     3. To include a structured content part in the message, the `| for_template` filter is used.

--- a/haystack_experimental/utils/jinja_chat_extension.py
+++ b/haystack_experimental/utils/jinja_chat_extension.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any, Callable, List, Optional, Union, get_args
+
+from haystack import logging
+from jinja2 import TemplateSyntaxError, nodes
+from jinja2.ext import Extension
+
+from haystack_experimental.dataclasses.chat_message import (
+    ChatMessage,
+    ChatMessageContentT,
+    ChatRole,
+    TextContent,
+    _deserialize_content_part,
+    _serialize_content_part,
+)
+
+logger = logging.getLogger(__name__)
+
+START_TAG = "<haystack_content_part>"
+END_TAG = "</haystack_content_part>"
+
+class ChatMessageExtension(Extension):
+    """
+    A Jinja2 extension for creating structured chat messages with mixed content types.
+
+    This extension provides a custom {% message %} tag that allows creating chat messages
+    with different attributes (role, name, meta) and mixed content types (text, images, etc.).
+
+    Inspired by [Banks](https://github.com/masci/banks).
+
+    Example:
+    {% message role="system" %}
+    You are a helpful assistant. You like to talk with {{user_name}}.
+    {% endmessage %}
+
+    {% message role="user" %}
+    Hello! I am {{user_name}}. Please describe the images.
+    {% for image in images %}
+    {{ image | for_template }}
+    {% endfor %}
+    {% endmessage %}
+
+    ## How it works
+    1. The {% message %} tag is used to define a chat message.
+    2. The message can contain text and other structured content parts.
+    3. To include a structured content part in the message, the `| for_template` filter is used.
+       The filter serializes the content part into a JSON string and wraps it in a `<haystack_content_part>` tag.
+    4. The `_build_chat_message_json` method of the extension parses the message content parts,
+       converts them into a ChatMessage object and serializes it to a JSON string.
+    5. The obtained JSON string is usable in the ChatPromptBuilder component, where templates are rendered to actual
+       ChatMessage objects.
+    """
+
+    SUPPORTED_ROLES = [role.value for role in ChatRole]
+
+    tags = {"message"}
+
+    def parse(self, parser: Any) -> Union[nodes.Node, List[nodes.Node]]:
+        """
+        Parse the message tag and its attributes in the Jinja2 template.
+
+        This method handles the parsing of role (mandatory), name (optional), meta (optional) and message body content.
+
+        :param parser: The Jinja2 parser instance
+        :return: A CallBlock node containing the parsed message configuration
+        :raises TemplateSyntaxError: If an invalid role is provided
+        """
+        lineno = next(parser.stream).lineno
+
+        # Parse role attribute (mandatory)
+        parser.stream.expect("name:role")
+        parser.stream.expect("assign")
+        role_expr = parser.parse_expression()
+
+        if isinstance(role_expr, nodes.Const):
+            role = role_expr.value
+            if role not in self.SUPPORTED_ROLES:
+                raise TemplateSyntaxError(f"Role must be one of: {', '.join(self.SUPPORTED_ROLES)}", lineno)
+
+        # Parse optional name attribute
+        name_expr = None
+        if parser.stream.current.test("name:name"):
+            parser.stream.skip()
+            parser.stream.expect("assign")
+            name_expr = parser.parse_expression()
+
+        # Parse optional meta attribute
+        meta_expr = None
+        if parser.stream.current.test("name:meta"):
+            parser.stream.skip()
+            parser.stream.expect("assign")
+            meta_expr = parser.parse_expression()
+
+        # Parse message body
+        body = parser.parse_statements(("name:endmessage",), drop_needle=True)
+
+        # Build message node with all parameters
+        return nodes.CallBlock(
+            self.call_method(
+                name="_build_chat_message_json",
+                args=[
+                    role_expr,
+                    name_expr or nodes.Const(None),
+                    meta_expr or nodes.Dict([]),
+                ],
+            ),
+            [],
+            [],
+            body,
+        ).set_lineno(lineno)
+
+    def _build_chat_message_json(self, role: str, name: Optional[str], meta: dict, caller: Callable[[], str]) -> str:
+        """
+        Build a ChatMessage object from template content and serialize it to a JSON string.
+
+        This method is called by Jinja2 when processing a {% message %} tag.
+        It takes the rendered content from the template, converts XML blocks into ChatMessageContentT objects,
+        creates a ChatMessage object and serializes it to a JSON string.
+
+        :param role: The role of the message
+        :param name: Optional name for the message sender
+        :param meta: Optional metadata dictionary
+        :param caller: Callable that returns the rendered content
+        :return: A JSON string representation of the ChatMessage object
+        :raises ValueError: If the message content is empty
+        """
+
+        content = caller()
+        parts = self._parse_content_parts(content)
+        if not parts:
+            raise ValueError("Message content is empty")
+        message = ChatMessage(_role=ChatRole(role), _content=parts, _name=name, _meta=meta)
+        return json.dumps(message.to_dict()) + "\n"
+
+    def _parse_content_parts(self, content: str) -> List[ChatMessageContentT]:
+        """
+        Parse a string into a sequence of ChatMessageContentT objects.
+
+        This method handles:
+        - Plain text content, converted to TextContent objects
+        - Structured content parts wrapped in <haystack_content_part> tags, converted to ChatMessageContentT objects
+
+        :param content: Input string containing mixed text and content parts
+        :return: A list of ChatMessageContentT objects
+        :raises ValueError: If a <haystack_content_part> tag is found without a matching closing tag
+        """
+        parts: List[ChatMessageContentT] = []
+        cursor = 0
+        total_length = len(content)
+
+        while cursor < total_length:
+            tag_start = content.find(START_TAG, cursor)
+
+            if tag_start == -1:
+                # No more tags, add remaining text if any
+                remaining_text = content[cursor:].strip()
+                if remaining_text:
+                    parts.append(TextContent(text=remaining_text))
+                break
+
+            # Add text before tag if any
+            if tag_start > cursor:
+                plain_text = content[cursor:tag_start].strip()
+                if plain_text:
+                    parts.append(TextContent(text=plain_text))
+
+            content_start = tag_start + len(START_TAG)
+            tag_end = content.find(END_TAG, content_start)
+
+            if tag_end == -1:
+                raise ValueError(
+                    f"Found unclosed <haystack_content_part> tag at position {tag_start}. "
+                    f"Content: '{content[tag_start:tag_start+50]}...'"
+                )
+
+
+            json_content = content[content_start:tag_end]
+            data = json.loads(json_content)
+            parts.append(_deserialize_content_part(data))
+
+            cursor = tag_end + len(END_TAG)
+
+        return parts
+
+
+def for_template(value: ChatMessageContentT) -> str:
+    """
+    Convert an ChatMessageContentT object into JSON string wrapped in special XML content tags.
+
+    :param value: The ChatMessageContentT object to convert
+    :return: A JSON string wrapped in special XML content tags
+    :raises ValueError: If the value is not an instance of ChatMessageContentT
+    """
+    chat_message_content_types = get_args(ChatMessageContentT)
+    if not isinstance(value, chat_message_content_types):
+        chat_message_content_types_str = ", ".join([t.__name__ for t in chat_message_content_types])
+        raise ValueError(f"Value must be an instance of one of the following types: {chat_message_content_types_str}. "
+                         f"Got: {type(value).__name__}")
+    return f"{START_TAG}{json.dumps(_serialize_content_part(value))}{END_TAG}"

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -352,6 +352,11 @@ def test_from_user_with_content_parts_fails_if_no_textual_parts():
     with pytest.raises(ValueError):
         ChatMessage.from_user(content_parts=[ImageContent(base64_image="base64_string")])
 
+def test_from_user_with_content_parts_fails_unsupported_parts():
+    with pytest.raises(ValueError):
+        ChatMessage.from_user(content_parts=["text part", 
+                                             ToolCall(id="123", tool_name="mytool", arguments={"a": 1})])
+
 def test_from_system_with_valid_content():
     text = "I have a question."
     message = ChatMessage.from_system(text=text)

--- a/test/utils/test_jinja_chat_extension.py
+++ b/test/utils/test_jinja_chat_extension.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+from jinja2 import TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
+
+from haystack_experimental.dataclasses.chat_message import ImageContent, ToolCall, ToolCallResult
+from haystack_experimental.utils.jinja_chat_extension import ChatMessageExtension, for_template
+
+
+class TestChatMessageExtension:
+    @pytest.fixture
+    def jinja_env(self) -> SandboxedEnvironment:
+        # we use a SandboxedEnvironment here to replicate the conditions of the ChatPromptBuilder component
+        env = SandboxedEnvironment(extensions=[ChatMessageExtension])
+        env.filters["for_template"] = for_template
+        return env
+
+    def test_message_with_name_and_meta(self, jinja_env):
+        template = """
+        {% message role="user" name="Bob" meta={"language": "en"} %}
+        Hello!
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "name": "Bob",
+            "content": [{"text": "Hello!"}],
+            "meta": {"language": "en"}
+        }
+        assert output == expected
+
+
+    def test_system_message(self, jinja_env):
+        template = """
+        {% message role="system" %}
+        You are a helpful assistant.
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "system",
+            "content": [{"text": "You are a helpful assistant."}],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_user_message_with_variable(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render(name="Alice")
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [{"text": "Hello, my name is Alice!"}],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_assistant_message_with_tool_call(self, jinja_env):
+        template = """
+        {% message role="assistant" %}
+        Let me search for that information.
+        {{ tool_call | for_template }}
+        {% endmessage %}
+        """
+        tool_call = ToolCall(
+            tool_name="search",
+            arguments={"query": "an interesting question"},
+            id="search_1"
+        )
+        rendered = jinja_env.from_string(template).render(tool_call=tool_call)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "assistant",
+            "content": [
+                {"text": "Let me search for that information."},
+                {"tool_call": {
+                    "tool_name": "search",
+                    "arguments": {"query": "an interesting question"},
+                    "id": "search_1"
+                }}
+            ],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_tool_message(self, jinja_env):
+        template = """
+        {% message role="tool" %}
+        {{ tool_result | for_template }}
+        {% endmessage %}
+        """
+        tool_call = ToolCall(
+            tool_name="search",
+            arguments={"query": "test"},
+            id="search_1"
+        )
+        tool_result = ToolCallResult(
+            result="Here are the search results",
+            origin=tool_call,
+            error=False
+        )
+        rendered = jinja_env.from_string(template).render(tool_result=tool_result)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "tool",
+            "content": [{
+                "tool_call_result": {
+                    "result": "Here are the search results",
+                    "error": False,
+                    "origin": {
+                        "tool_name": "search",
+                        "arguments": {"query": "test"},
+                        "id": "search_1"
+                    }
+                }
+            }],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_user_message_with_image(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Please describe this image:
+        {{ image | for_template }}
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image="test_base64", mime_type="image/jpeg")
+        rendered = jinja_env.from_string(template).render(image=image)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": "Please describe this image:"},
+                {"image": {
+                    "base64_image": "test_base64",
+                    "mime_type": "image/jpeg",
+                    "detail": None,
+                    "meta": {}
+                }}
+            ],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+
+    def test_user_message_with_multiple_images(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Compare these images:
+        {% for img in images %}
+        {{ img | for_template }}
+        {% endfor %}
+        {% endmessage %}
+        """
+        images = [
+            ImageContent(base64_image="test_base64_1", mime_type="image/jpeg"),
+            ImageContent(base64_image="test_base64_2", mime_type="image/png")
+        ]
+        rendered = jinja_env.from_string(template).render(images=images)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": "Compare these images:"},
+                {"image": {
+                    "base64_image": "test_base64_1",
+                    "mime_type": "image/jpeg",
+                    "detail": None,
+                    "meta": {}
+                }},
+                {"image": {
+                    "base64_image": "test_base64_2",
+                    "mime_type": "image/png",
+                    "detail": None,
+                    "meta": {}
+                }}
+            ],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_user_message_with_multiple_images_and_interleaved_text(self, jinja_env):
+        """
+        Tests that messages with multiple images and interleaved text are rendered correctly.
+        This format is used by Anthropic models:
+        https://docs.anthropic.com/en/docs/build-with-claude/vision#example-multiple-images
+        """
+        template = """
+        {% message role="user" %}
+        {% for image in images %}
+        Image {{ loop.index }}:
+        {{ image | for_template }}
+        {% endfor %}
+        What's the difference between the two images?
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image="test_base64", mime_type="image/jpeg")
+        rendered = jinja_env.from_string(template).render(images=[image, image])
+        output = json.loads(rendered.strip())
+
+        expected = {
+            "role": "user",
+            "content": [{"text": "Image 1:"},
+                        {"image": {
+                            "base64_image": "test_base64",
+                            "mime_type": "image/jpeg",
+                            "detail": None,
+                            "meta": {}
+                        }},
+                        {"text": "Image 2:"},
+                        {"image": {
+                            "base64_image": "test_base64",
+                            "mime_type": "image/jpeg",
+                            "detail": None,
+                            "meta": {}
+                        }},
+                        {"text": "What's the difference between the two images?"}
+            ],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_user_message_multiple_lines(self, jinja_env):
+        template = """
+{% message role="user" %}
+What do you think of NLP?
+It's an interesting domain, if you ask me.
+But my favorite subject is Small Language Models.
+{% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": ("What do you think of NLP?\nIt's an interesting domain, if you ask me.\n"
+                          "But my favorite subject is Small Language Models."
+                          )},
+            ],
+            "name": None,
+            "meta": {}
+        }
+        assert output == expected
+
+    def test_invalid_role(self, jinja_env):
+        template = """
+        {% message role="invalid_role" %}
+        This should fail
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="Role must be one of"):
+            jinja_env.from_string(template).render()
+
+    def test_for_template_filter_with_invalid_type(self):
+        with pytest.raises(ValueError, match="Value must be an instance of one of the following types"):
+            for_template(123)
+
+    def test_empty_message_content_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError, match="Message content is empty"):
+            jinja_env.from_string(template).render()
+
+
+    def test_message_with_whitespace_handling(self, jinja_env):
+        # the following templates should all be equivalent
+        templates = [
+            """{% message role="user" %}{{ image | for_template }}{% endmessage %}""",
+            """{% message role="user" %}    {{ image | for_template }}    {% endmessage %}""",
+            """{% message role="user" %}
+            {{ image | for_template }}
+            {% endmessage %}""",
+            """{% message role="user" %}\t{{ image | for_template }}\t{% endmessage %}"""
+        ]
+        image = ImageContent(base64_image="test_base64", mime_type="image/jpeg")
+        expected = {
+            "role": "user",
+            "content": [
+                {"image": {
+                    "base64_image": "test_base64",
+                    "mime_type": "image/jpeg",
+                    "detail": None,
+                    "meta": {}
+                }}
+            ],
+            "name": None,
+            "meta": {}
+        }
+        for template in templates:
+            rendered = jinja_env.from_string(template).render(image=image)
+            output = json.loads(rendered.strip())
+            assert output == expected
+
+    def test_unclosed_content_tag_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        <haystack_content_part>{"type": "text", "text": "Hello"}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError, match="Found unclosed <haystack_content_part> tag"):
+            jinja_env.from_string(template).render()
+
+
+    def test_invalid_json_in_content_part_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Normal text before.
+        <haystack_content_part>{"this is": "invalid" json}</haystack_content_part>
+        <haystack_content_part>not even trying to be json</haystack_content_part>
+        <haystack_content_part>{]</haystack_content_part>
+        Normal text after.
+        {% endmessage %}
+        """
+        with pytest.raises(json.JSONDecodeError):
+            jinja_env.from_string(template).render()
+
+

--- a/test/utils/test_jinja_chat_extension.py
+++ b/test/utils/test_jinja_chat_extension.py
@@ -53,6 +53,32 @@ class TestChatMessageExtension:
         with pytest.raises(TemplateSyntaxError, match="expected token 'role'"):
             jinja_env.from_string(template).render()
 
+    def test_message_meta_not_dict_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" meta="not a dict" %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="meta must be a dictionary"):
+            jinja_env.from_string(template).render()
+
+    def test_message_meta_invalid_dict_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" meta={"key": "unclosed_value} %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError):
+            jinja_env.from_string(template).render()            
+
+    def test_message_name_not_str_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" name=123 %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="name must be a string"):
+            jinja_env.from_string(template).render()
 
     def test_system_message(self, jinja_env):
         template = """

--- a/test/utils/test_jinja_chat_extension.py
+++ b/test/utils/test_jinja_chat_extension.py
@@ -44,6 +44,14 @@ class TestChatMessageExtension:
         with pytest.raises(TemplateSyntaxError, match="Jinja was looking for the following tags: 'endmessage'"):
             jinja_env.from_string(template).render()
 
+    def test_message_no_role_raises_error(self, jinja_env):
+        template = """
+        {% message %}
+        You are a helpful assistant.
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="expected token 'role'"):
+            jinja_env.from_string(template).render()
 
 
     def test_system_message(self, jinja_env):

--- a/test/utils/test_jinja_chat_extension.py
+++ b/test/utils/test_jinja_chat_extension.py
@@ -36,6 +36,15 @@ class TestChatMessageExtension:
         }
         assert output == expected
 
+    def test_message_no_endmessage_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Hello!
+        """
+        with pytest.raises(TemplateSyntaxError, match="Jinja was looking for the following tags: 'endmessage'"):
+            jinja_env.from_string(template).render()
+
+
 
     def test_system_message(self, jinja_env):
         template = """


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack/issues/9260: I'm not yet modifying the `ChatPromptBuilder` but introducing the foundations to make it work

### Proposed Changes:
- introduce a Jinja2 ChatMessage extension
    1. The `{% message %}` tag is used to define a chat message.
    2. The message can contain text and other structured content parts.
    3. To include a structured content part in the message, the `| for_template` filter is used.
       The filter serializes the content part into a JSON string and wraps it in a `<haystack_content_part>` tag.
    4. The `_build_chat_message_json` method of the extension parses the message content parts,
       converts them into a `ChatMessage` object and serializes it to a JSON string.
    5. The obtained JSON string will be usable in the `ChatPromptBuilder` component, where templates are rendered to actual `ChatMessage` objects.

### How did you test it?
CI; several tests for the extension

### Notes for the reviewer
- Don't get scared by the size of this PR (there are many tests)
- (I'll keep working on the `ChatPromptBuilder` using this basis)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
