### PR TITLE
feat: `ImageContent` visualization

### DIFF
--- a/haystack_experimental/dataclasses/image_content.py
+++ b/haystack_experimental/dataclasses/image_content.py
@@ -6,12 +6,17 @@ import base64
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple, Union
+from io import BytesIO
 
 import filetype
 from haystack import logging
+from haystack.lazy_imports import LazyImport
 from haystack.components.fetchers.link_content import LinkContentFetcher
 
 from haystack_experimental.components.image_converters.image_utils import MIME_TO_FORMAT
+
+with LazyImport("The 'show' method requires the 'PIL' library. Run 'pip install pillow'") as pillow_import:
+    from PIL import Image
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +73,15 @@ class ImageContent:
         fields.append(f"meta={self.meta!r}")
         fields_str = ", ".join(fields)
         return f"{self.__class__.__name__}({fields_str})"
+    
+    def show(self) -> None:
+        """
+        Shows the image.
+        """
+        pillow_import.check()
+        image_bytes = BytesIO(base64.b64decode(self.base64_image))
+        image = Image.open(image_bytes)
+        image.show()
 
     @classmethod
     def from_file_path(

--- a/haystack_experimental/dataclasses/image_content.py
+++ b/haystack_experimental/dataclasses/image_content.py
@@ -7,10 +7,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 from io import BytesIO
+from IPython.display import display
 
 import filetype
 from haystack import logging
 from haystack.lazy_imports import LazyImport
+from haystack.utils import is_in_jupyter
 from haystack.components.fetchers.link_content import LinkContentFetcher
 
 from haystack_experimental.components.image_converters.image_utils import MIME_TO_FORMAT
@@ -81,7 +83,11 @@ class ImageContent:
         pillow_import.check()
         image_bytes = BytesIO(base64.b64decode(self.base64_image))
         image = Image.open(image_bytes)
-        image.show()
+        
+        if is_in_jupyter():
+            display(image)
+        else:
+            image.show()
 
     @classmethod
     def from_file_path(

--- a/haystack_experimental/dataclasses/image_content.py
+++ b/haystack_experimental/dataclasses/image_content.py
@@ -4,16 +4,16 @@
 
 import base64
 from dataclasses import dataclass, field
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple, Union
-from io import BytesIO
-from IPython.display import display
 
 import filetype
 from haystack import logging
+from haystack.components.fetchers.link_content import LinkContentFetcher
 from haystack.lazy_imports import LazyImport
 from haystack.utils import is_in_jupyter
-from haystack.components.fetchers.link_content import LinkContentFetcher
+from IPython.display import display
 
 from haystack_experimental.components.image_converters.image_utils import MIME_TO_FORMAT
 
@@ -75,7 +75,7 @@ class ImageContent:
         fields.append(f"meta={self.meta!r}")
         fields_str = ", ".join(fields)
         return f"{self.__class__.__name__}({fields_str})"
-    
+
     def show(self) -> None:
         """
         Shows the image.
@@ -83,7 +83,7 @@ class ImageContent:
         pillow_import.check()
         image_bytes = BytesIO(base64.b64decode(self.base64_image))
         image = Image.open(image_bytes)
-        
+
         if is_in_jupyter():
             display(image)
         else:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9364

### Proposed Changes:

- add `ImageContent.show()` method to display the underlying image
  - in Jupyter, uses [`IPython.display.display`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display)
  - in other platforms, uses [`PIL.Image.show`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.show), which calls the appropriate executable depending on the operating systems

### How did you test it?
CI; new tests
[Example notebook](https://colab.research.google.com/drive/1vPBa58BcHFjL_RBU4LMzn36T0EqbLH7U?usp=sharing)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
