### PR TITLE
fix: move IPython import

### DIFF
--- a/haystack_experimental/dataclasses/image_content.py
+++ b/haystack_experimental/dataclasses/image_content.py
@@ -13,7 +13,6 @@ from haystack import logging
 from haystack.components.fetchers.link_content import LinkContentFetcher
 from haystack.lazy_imports import LazyImport
 from haystack.utils import is_in_jupyter
-from IPython.display import display
 
 from haystack_experimental.components.image_converters.image_utils import MIME_TO_FORMAT
 
@@ -85,6 +84,8 @@ class ImageContent:
         image = Image.open(image_bytes)
 
         if is_in_jupyter():
+            # ipython is not a core dependency so we cannot import it at the module level
+            from IPython.display import display
             display(image)
         else:
             image.show()

--- a/test/dataclasses/test_image_content.py
+++ b/test/dataclasses/test_image_content.py
@@ -42,7 +42,7 @@ def test_image_content_show_in_jupyter(test_files_path):
     )
 
     with patch("haystack_experimental.dataclasses.image_content.is_in_jupyter", return_value=True), \
-        patch("haystack_experimental.dataclasses.image_content.display") as mock_display:
+        patch("IPython.display.display") as mock_display:
         image_content.show()
 
         mock_display.assert_called_once()


### PR DESCRIPTION
### Related Issues

When experiment in a fresh virtual environment with `ImageContent`, I got
`ModuleNotFoundError: No module named 'IPython'`

### Proposed Changes:
- move the IPython import inside the `if is_in_jupyter():` condition

### How did you test it?
CI, updated test. Also tested locally in a fresh virtual environment

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
