### PR TITLE
chore: fix format for `DocumentToImageContent`

### DIFF
--- a/haystack_experimental/components/image_converters/document_to_image.py
+++ b/haystack_experimental/components/image_converters/document_to_image.py
@@ -65,7 +65,7 @@ class DocumentToImageContent:
         file_path_meta_field: str = "file_path",
         root_path: Optional[str] = None,
         detail: Optional[Literal["auto", "high", "low"]] = None,
-        size: Optional[Tuple[int, int]] = None
+        size: Optional[Tuple[int, int]] = None,
     ):
         """
         Initialize the DocumentToImageContent component.
@@ -147,22 +147,26 @@ class DocumentToImageContent:
                 image_contents.extend(
                     # Possible for _pdf_to_image_converter to return multiple images depending on the page range
                     self._pdf_to_image_converter.run(
-                        sources=[ByteStream.from_file_path(
-                            filepath=resolved_file_path,
-                            mime_type="application/pdf",
-                            meta={"page_number": doc.meta["page_number"], "file_path": doc.meta["file_path"]}
-                        )],
+                        sources=[
+                            ByteStream.from_file_path(
+                                filepath=resolved_file_path,
+                                mime_type="application/pdf",
+                                meta={"page_number": doc.meta["page_number"], "file_path": doc.meta["file_path"]},
+                            )
+                        ],
                         page_range=[doc.meta["page_number"]],
                     )["image_contents"]
                 )
             else:
                 image_contents.extend(
                     self._file_to_image_converter.run(
-                        sources=[ByteStream.from_file_path(
-                            filepath=resolved_file_path,
-                            mime_type=mime_type,
-                            meta={"file_path": doc.meta["file_path"]}
-                        )]
+                        sources=[
+                            ByteStream.from_file_path(
+                                filepath=resolved_file_path,
+                                mime_type=mime_type,
+                                meta={"file_path": doc.meta["file_path"]},
+                            )
+                        ]
                     )["image_contents"]
                 )
 


### PR DESCRIPTION
### Related Issues

- linting failing on main: https://github.com/deepset-ai/haystack-experimental/actions/runs/15486519469/job/43602322860
- I merged #315 without first merging main

### Proposed Changes:
- format `DocumentToImageContent`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
