### PR TITLE
chore: ignore type errors in Bedrock monkey patches

### DIFF
--- a/haystack_experimental/components/generators/chat/amazon_bedrock.py
+++ b/haystack_experimental/components/generators/chat/amazon_bedrock.py
@@ -142,9 +142,9 @@ else:
         return system_prompts, repaired_bedrock_formatted_messages
 
     # NOTE: monkey patches needed to use the new ChatMessage dataclass and _format_messages function
-    original_utils.ChatMessage = ChatMessage
-    original_chat_generator.ChatMessage = ChatMessage
-    original_chat_generator._format_messages = _format_messages
+    original_utils.ChatMessage = ChatMessage  # type: ignore[misc]
+    original_chat_generator.ChatMessage = ChatMessage  # type: ignore[misc]
+    original_chat_generator._format_messages = _format_messages  # type: ignore[assignment]
 
     @component
     class AmazonBedrockChatGenerator(original_chat_generator.AmazonBedrockChatGenerator):  # type: ignore[no-redef]


### PR DESCRIPTION
### Related Issues
- I just released a new version of `amazon-bedrock-haystack`, shipping type support implemented in https://github.com/deepset-ai/haystack-core-integrations/pull/1925
- Now mypy complains: https://github.com/deepset-ai/haystack-experimental/actions/runs/15586489977/job/43893927159?pr=319

### Proposed Changes:
- Ignore mypy errors: monkey patches are tricky and mypy is expected to complain now that `amazon-bedrock-haystack` types are usable in downstream libraries.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
