### PR TITLE
fix: Fix storage of file path in ImageContent

### DIFF
--- a/haystack_experimental/components/image_converters/document_to_image.py
+++ b/haystack_experimental/components/image_converters/document_to_image.py
@@ -145,7 +145,7 @@ class DocumentToImageContent:
                     base64_image=base64_image,
                     mime_type=mime_type,
                     detail=self.detail,
-                    meta={"file_path": documents[doc_idx].meta[self.file_path_meta_field]}
+                    meta={"file_path": documents[doc_idx].meta[self.file_path_meta_field]},
                 )
 
         # efficiently convert PDF pages to images: each PDF is opened and processed only once

--- a/haystack_experimental/components/image_converters/document_to_image.py
+++ b/haystack_experimental/components/image_converters/document_to_image.py
@@ -142,7 +142,10 @@ class DocumentToImageContent:
                 bytestream = ByteStream.from_file_path(filepath=path, mime_type=mime_type)
                 _, base64_image = _encode_image_to_base64(bytestream=bytestream, size=self.size)
                 image_contents[doc_idx] = ImageContent(
-                    base64_image=base64_image, mime_type=mime_type, detail=self.detail, meta={"file_path": path}
+                    base64_image=base64_image,
+                    mime_type=mime_type,
+                    detail=self.detail,
+                    meta={"file_path": documents[doc_idx].meta[self.file_path_meta_field]}
                 )
 
         # efficiently convert PDF pages to images: each PDF is opened and processed only once

--- a/test/components/image_converters/test_document_to_image_content.py
+++ b/test/components/image_converters/test_document_to_image_content.py
@@ -78,12 +78,16 @@ class TestDocumentToImageContent:
         image_doc = Document(content="test", meta={"file_path": "apple.jpg"})
         results = converter.run(documents=[image_doc])
         assert len(results["image_contents"]) == 1
+        assert results["image_contents"][0].meta == {"file_path": "apple.jpg"}
 
     def test_run_with_pdf_documents(self) -> None:
         converter = DocumentToImageContent()
         pdf_doc = Document(content="test", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf", "page_number": 1})
         results = converter.run(documents=[pdf_doc])
         assert len(results["image_contents"]) == 1
+        assert results["image_contents"][0].meta == {
+            "file_path": "test/test_files/pdf/sample_pdf_1.pdf", "page_number": 1
+        }
 
     def test_run_with_mixed_document_types(self) -> None:
         converter = DocumentToImageContent(root_path="test/test_files")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Update DocumentToImageContent to store the file path in meta as a string and not as a Path object

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
