### PR TITLE
feat: Add `normalize_embeddings` to `SentenceTransformersDocumentImageEmbedder` to match signature of other embedders

### DIFF
--- a/haystack_experimental/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack_experimental/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -45,6 +45,7 @@ class SentenceTransformersDocumentImageEmbedder:
         token: Optional[Secret] = Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False),
         batch_size: int = 32,
         progress_bar: bool = True,
+        normalize_embeddings: bool = False,
         trust_remote_code: bool = False,
         local_files_only: bool = False,
         model_kwargs: Optional[Dict[str, Any]] = None,
@@ -73,6 +74,8 @@ class SentenceTransformersDocumentImageEmbedder:
             Number of documents to embed at once.
         :param progress_bar:
             If `True`, shows a progress bar when embedding documents.
+        :param normalize_embeddings:
+            If `True`, the embeddings are normalized using L2 normalization, so that each embedding has a norm of 1.
         :param trust_remote_code:
             If `False`, allows only Hugging Face verified model architectures.
             If `True`, allows custom models and scripts.
@@ -109,6 +112,7 @@ class SentenceTransformersDocumentImageEmbedder:
         self.token = token
         self.batch_size = batch_size
         self.progress_bar = progress_bar
+        self.normalize_embeddings = normalize_embeddings
         self.trust_remote_code = trust_remote_code
         self.local_files_only = local_files_only
         self.model_kwargs = model_kwargs
@@ -135,6 +139,7 @@ class SentenceTransformersDocumentImageEmbedder:
             token=self.token.to_dict() if self.token else None,
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
+            normalize_embeddings=self.normalize_embeddings,
             trust_remote_code=self.trust_remote_code,
             local_files_only=self.local_files_only,
             model_kwargs=self.model_kwargs,
@@ -244,6 +249,7 @@ class SentenceTransformersDocumentImageEmbedder:
             images_to_embed,  # type: ignore[arg-type]
             batch_size=self.batch_size,
             show_progress_bar=self.progress_bar,
+            normalize_embeddings=self.normalize_embeddings,
             precision=self.precision,
             **(self.encode_kwargs if self.encode_kwargs else {}),
         )

--- a/test/components/embedders/test_sentence_transformers_doc_image_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_doc_image_embedder.py
@@ -80,6 +80,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
                 "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
                 "batch_size": 32,
                 "progress_bar": True,
+                "normalize_embeddings": False,
                 "trust_remote_code": False,
                 "local_files_only": False,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
@@ -100,6 +101,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             "token": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
             "batch_size": 64,
             "progress_bar": False,
+            "normalize_embeddings": True,
             "trust_remote_code": True,
             "local_files_only": True,
             "model_kwargs": {"torch_dtype": "torch.float32"},
@@ -120,6 +122,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
         assert component.token == Secret.from_env_var("ENV_VAR", strict=False)
         assert component.batch_size == 64
         assert component.progress_bar is False
+        assert component.normalize_embeddings is True
         assert component.trust_remote_code
         assert component.local_files_only
         assert component.model_kwargs == {"torch_dtype": torch.float32}
@@ -137,6 +140,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             "token": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
             "batch_size": 64,
             "progress_bar": False,
+            "normalize_embeddings": False,
             "trust_remote_code": True,
             "local_files_only": False,
             "precision": "float32",


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add normalize_embeddings to SentenceTransformersDocumentImageEmbedder to match signature of other embedders in Haystack

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
updated unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
