### PR TITLE
feat: Add ImageFileToDocument converter

### DIFF
--- a/haystack_experimental/components/converters/image/__init__.py
+++ b/haystack_experimental/components/converters/image/__init__.py
@@ -10,12 +10,14 @@ from lazy_imports import LazyImporter
 _import_structure = {
     "document_to_image": ["DocumentToImageContent"],
     "file_to_image": ["ImageFileToImageContent"],
+    "image_to_document": ["ImageFileToDocument"],
     "pdf_to_image": ["PDFToImageContent"],
 }
 
 if TYPE_CHECKING:
     from .document_to_image import DocumentToImageContent
     from .file_to_image import ImageFileToImageContent
+    from .image_to_document import ImageFileToDocument
     from .pdf_to_image import PDFToImageContent
 else:
     sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack_experimental/components/converters/image/document_to_image.py
+++ b/haystack_experimental/components/converters/image/document_to_image.py
@@ -149,13 +149,16 @@ class DocumentToImageContent:
                 )
 
         # efficiently convert PDF pages to images: each PDF is opened and processed only once
+        pdf_page_infos_by_doc_idx: Dict[int, _PDFPageInfo] = {
+            pdf_page_info["doc_idx"]: pdf_page_info for pdf_page_info in pdf_page_infos
+        }
         pdf_images_by_doc_idx = _batch_convert_pdf_pages_to_images(
             pdf_page_infos=pdf_page_infos, size=self.size, return_base64=True
         )
         for doc_idx, base64_pdf_image in pdf_images_by_doc_idx.items():
             meta = {
                 "file_path": documents[doc_idx].meta[self.file_path_meta_field],
-                "page_number": pdf_page_infos[doc_idx]["page_number"],
+                "page_number": pdf_page_infos_by_doc_idx[doc_idx]["page_number"],
             }
             # we know that base64_pdf_image is a string because we set return_base64=True but mypy doesn't know that
             assert isinstance(base64_pdf_image, str)

--- a/haystack_experimental/components/converters/image/image_to_document.py
+++ b/haystack_experimental/components/converters/image/image_to_document.py
@@ -38,6 +38,7 @@ class ImageFileToDocument:
     @component.output_types(documents=List[Document])
     def run(
         self,
+        *,
         sources: List[Union[str, Path, ByteStream]],
         meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
     ) -> Dict[str, List[Document]]:

--- a/haystack_experimental/components/converters/image/image_to_document.py
+++ b/haystack_experimental/components/converters/image/image_to_document.py
@@ -16,12 +16,18 @@ logger = logging.getLogger(__name__)
 @component
 class ImageFileToDocument:
     """
-    Converts image files to Document objects.
+    Converts image file references into empty Document objects with associated metadata.
+
+    This component is useful in pipelines where image file paths need to be wrapped in `Document` objects to be
+    processed by downstream components such as the `SentenceTransformersImageDocumentEmbedder`.
+
+    It does **not** extract any content from the image files, instead it creates `Document` objects with `None` as
+    their content and attaches metadata such as file path and any user-provided values.
     """
 
     def __init__(self, *, store_full_path: bool = False):
         """
-        Create the ImageFileToDocument component.
+        Initialize the ImageFileToDocument component.
 
         :param store_full_path:
             If True, the full path of the file is stored in the metadata of the document.
@@ -36,7 +42,11 @@ class ImageFileToDocument:
         meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
     ) -> Dict[str, List[Document]]:
         """
-        Converts Image files to Document objects.
+        Convert image files into empty Document objects with metadata.
+
+        This method accepts image file references (as file paths or ByteStreams) and creates `Document` objects
+        without content. These documents are enriched with metadata derived from the input source and optional
+        user-provided metadata.
 
         :param sources:
             List of file paths or ByteStream objects to convert.
@@ -48,9 +58,10 @@ class ImageFileToDocument:
             For ByteStream objects, their `meta` is added to the output documents.
 
         :returns:
-            A dictionary with the following keys:
-            - `documents`: A list of converted documents.
+            A dictionary containing:
+            - `documents`: A list of `Document` objects with empty content and associated metadata.
         """
+
         documents = []
         meta_list = normalize_metadata(meta, sources_count=len(sources))
 

--- a/haystack_experimental/components/converters/image/image_to_document.py
+++ b/haystack_experimental/components/converters/image/image_to_document.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from haystack import Document, component, logging
+from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
+from haystack.dataclasses import ByteStream
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class ImageFileToDocument:
+    """
+    Converts image files to Document objects.
+    """
+
+    def __init__(self, *, store_full_path: bool = False):
+        """
+        Create the ImageFileToDocument component.
+
+        :param store_full_path:
+            If True, the full path of the file is stored in the metadata of the document.
+            If False, only the file name is stored.
+        """
+        self.store_full_path = store_full_path
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        sources: List[Union[str, Path, ByteStream]],
+        meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+    ):
+        """
+        Converts Image files to Document objects.
+
+        :param sources:
+            List of file paths or ByteStream objects to convert.
+        :param meta:
+            Optional metadata to attach to the documents.
+            This value can be a list of dictionaries or a single dictionary.
+            If it's a single dictionary, its content is added to the metadata of all produced documents.
+            If it's a list, its length must match the number of sources, as they are zipped together.
+            For ByteStream objects, their `meta` is added to the output documents.
+
+        :returns:
+            A dictionary with the following keys:
+            - `documents`: A list of converted documents.
+        """
+        documents = []
+        meta_list = normalize_metadata(meta, sources_count=len(sources))
+
+        for source, metadata in zip(sources, meta_list):
+            try:
+                bytestream = get_bytestream_from_source(source)
+            except Exception as e:
+                logger.warning("Could not read {source}. Skipping it. Error: {error}", source=source, error=e)
+                continue
+
+            merged_metadata = {**bytestream.meta, **metadata}
+
+            if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
+                merged_metadata["file_path"] = os.path.basename(file_path)
+            document = Document(content=None, meta=merged_metadata)
+            documents.append(document)
+
+        return {"documents": documents}

--- a/haystack_experimental/components/converters/image/image_to_document.py
+++ b/haystack_experimental/components/converters/image/image_to_document.py
@@ -34,7 +34,7 @@ class ImageFileToDocument:
         self,
         sources: List[Union[str, Path, ByteStream]],
         meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Converts Image files to Document objects.
 

--- a/test/components/converters/image/test_image_to_document.py
+++ b/test/components/converters/image/test_image_to_document.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+from haystack.core.serialization import component_from_dict, component_to_dict
+from haystack.dataclasses import ByteStream
+
+from haystack_experimental.components.converters.image.image_to_document import ImageFileToDocument
+
+
+class TestImageFileToDocument:
+    def test_to_dict(self) -> None:
+        converter = ImageFileToDocument()
+        assert component_to_dict(converter, "converter") == {
+            "init_parameters": {"store_full_path": False},
+            "type": "haystack_experimental.components.converters.image.image_to_document.ImageFileToDocument",
+        }
+
+    def test_to_dict_not_defaults(self) -> None:
+        converter = ImageFileToDocument(store_full_path=True)
+        assert component_to_dict(converter, "converter") == {
+            "init_parameters": {"store_full_path": True},
+            "type": "haystack_experimental.components.converters.image.image_to_document.ImageFileToDocument",
+        }
+
+    def test_from_dict(self) -> None:
+        data = {
+            "init_parameters": {"store_full_path": False},
+            "type": "haystack_experimental.components.converters.image.image_to_document.ImageFileToDocument",
+        }
+        converter = component_from_dict(ImageFileToDocument, data, "name")
+        assert component_to_dict(converter, "converter") == data
+
+    @pytest.mark.parametrize(
+        ("image_path", "mime_type"),
+        [
+            ("./test/test_files/images/haystack-logo.png", "image/png"),
+            ("./test/test_files/images/apple.jpg", "image/jpeg"),
+        ],
+    )
+    def test_run_with_valid_sources(self, image_path: str, mime_type: str) -> None:
+        converter = ImageFileToDocument(store_full_path=True)
+        results = converter.run(sources=[image_path], meta={"source": "test_source"})
+
+        assert len(results["documents"]) == 1
+        assert results["documents"][0].content is None
+        assert results["documents"][0].meta == {
+            "source": "test_source", "file_path": image_path,
+        }
+
+    def test_run_with_no_sources(self) -> None:
+        converter = ImageFileToDocument()
+        results = converter.run(sources=[])
+        assert len(results["documents"]) == 0
+        assert results == {"documents": []}
+
+    def test_run_with_invalid_source_type(self, caplog) -> None:
+        converter = ImageFileToDocument()
+        converter.run(sources=[123])  # Invalid source type
+        assert "Could not read" in caplog.text
+
+    def test_run_with_non_existent_file(self, caplog) -> None:
+        converter = ImageFileToDocument()
+        converter.run(sources=["./non_existent_file.png"])
+        assert "Could not read" in caplog.text
+        assert "No such file or directory:" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("image_path", "mime_type"),
+        [
+            ("./test/test_files/images/haystack-logo.png", "image/png"),
+            ("./test/test_files/images/apple.jpg", "image/jpeg"),
+        ],
+    )
+    def test_run_with_bytestream_sources(self, image_path: str, mime_type: str) -> None:
+        byte_stream = ByteStream.from_file_path(Path(image_path), mime_type=mime_type, meta={"file_path": image_path})
+        converter = ImageFileToDocument(store_full_path=True)
+        results = converter.run(sources=[byte_stream])
+        assert len(results["documents"]) == 1
+        assert results["documents"][0].content is None
+        assert results["documents"][0].meta == {"file_path": image_path}


### PR DESCRIPTION
### Related Issues

- partially addresses https://github.com/deepset-ai/haystack/issues/9321

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a `ImageFileToDocument` converter so images can be converted from sources into Documents and then handed off to DocumentWriter or Image Document Embedder. 

Here is an example indexing + query pipeline showing how this can be used. Run this script from within the top-level directory of this repo to properly load all sources.

<details>

<summary> Indexing Example </summary>

```python
import os
from pathlib import Path
from typing import List

# To avoid warnings about parallelism in tokenizers
os.environ["TOKENIZERS_PARALLELISM"] = "false"

from haystack import Pipeline
from haystack.components.converters.docx import DOCXToDocument
from haystack.components.converters.pypdf import PyPDFToDocument
from haystack.components.embedders.sentence_transformers_document_embedder import SentenceTransformersDocumentEmbedder
from haystack.components.embedders.sentence_transformers_text_embedder import SentenceTransformersTextEmbedder
from haystack.components.joiners import DocumentJoiner, ListJoiner
from haystack.components.preprocessors.document_splitter import DocumentSplitter
from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
from haystack.components.routers.file_type_router import FileTypeRouter
from haystack.components.writers.document_writer import DocumentWriter
from haystack.document_stores.in_memory import InMemoryDocumentStore

from haystack_experimental.components.builders.chat_prompt_builder import ChatPromptBuilder
from haystack_experimental.components.embedders.image.sentence_transformers_doc_image_embedder import (
    SentenceTransformersDocumentImageEmbedder,
)
from haystack_experimental.components.generators.chat.openai import OpenAIChatGenerator
from haystack_experimental.components.converters.image.document_to_image import DocumentToImageContent
from haystack_experimental.components.converters.image.image_to_document import ImageFileToDocument
from haystack_experimental.components.routers.document_type_router import DocumentTypeRouter


#
# Indexing documents
#

document_store = InMemoryDocumentStore(embedding_similarity_function="cosine")

file_type_router = FileTypeRouter(
    mime_types=[
        "application/pdf",
        "image/jpeg",
        "image/png",
        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
    ]
)
pdf_converter = PyPDFToDocument(store_full_path=True)
pdf_splitter = DocumentSplitter(split_by="page", split_length=1)
docx_converter = DOCXToDocument(store_full_path=True)
image_converter = ImageFileToDocument(store_full_path=True)
text_doc_joiner = DocumentJoiner(sort_by_score=False)
image_source_joiner = ListJoiner(list_type_=List[Path])
final_doc_joiner = DocumentJoiner(sort_by_score=False)

# NOTE: We have to use the same embedding model for both text and image embeddings to ensure both images and text are
# represented in the same vector space.
image_doc_embedder = SentenceTransformersDocumentImageEmbedder(
    file_path_meta_field="file_path",
    # model="sentence-transformers/clip-ViT-B-32",
    model="sentence-transformers/clip-ViT-L-14",
    # normalize_embeddings=True,
    progress_bar=False,
)
text_doc_embedder = SentenceTransformersDocumentEmbedder(
    # model="sentence-transformers/clip-ViT-B-32",
    model="sentence-transformers/clip-ViT-L-14",
    # normalize_embeddings=True,
    progress_bar=False,
)

document_writer = DocumentWriter(document_store=document_store)

# Create the Indexing pipeline
pipe = Pipeline()
pipe.add_component("file_type_router", file_type_router)
pipe.add_component("pdf_converter", pdf_converter)
pipe.add_component("pdf_splitter", pdf_splitter)
pipe.add_component("docx_converter", docx_converter)
pipe.add_component("image_converter", image_converter)
pipe.add_component("text_doc_joiner", text_doc_joiner)
pipe.add_component("image_source_joiner", image_source_joiner)
pipe.add_component("text_doc_embedder", text_doc_embedder)
pipe.add_component("image_doc_embedder", image_doc_embedder)
pipe.add_component("final_doc_joiner", final_doc_joiner)
pipe.add_component("document_writer", document_writer)

pipe.connect("file_type_router.application/pdf", "pdf_converter.sources")
pipe.connect("pdf_converter.documents", "pdf_splitter.documents")
pipe.connect("pdf_splitter.documents", "text_doc_joiner.documents")
pipe.connect(
    "file_type_router.application/vnd.openxmlformats-officedocument.wordprocessingml.document",
    "docx_converter.sources"
)
pipe.connect("docx_converter.documents", "text_doc_joiner.documents")
pipe.connect("file_type_router.image/jpeg", "image_source_joiner.values")
pipe.connect("file_type_router.image/png", "image_source_joiner.values")
pipe.connect("image_source_joiner.values", "image_converter.sources")
pipe.connect("text_doc_joiner.documents", "text_doc_embedder.documents")
pipe.connect("image_converter.documents", "image_doc_embedder.documents")
pipe.connect("text_doc_embedder.documents", "final_doc_joiner.documents")
pipe.connect("image_doc_embedder.documents", "final_doc_joiner.documents")
pipe.connect("final_doc_joiner.documents", "document_writer.documents")

# Run the indexing pipeline with sources
# NOTE: We expect no outputs since the pipeline ends with a DocumentWriter component.
indexing_result = pipe.run(
    data={
        "file_type_router": {
            # These can be strings, Paths, or ByteStreams.
            "sources": [
                "test/test_files/pdf/sample_pdf_1.pdf",
                "test/test_files/images/apple.jpg",
                "test/test_files/docx/sample_docx.docx",
                "test/test_files/images/haystack-logo.png",
            ]
        }
    },
)

# Inspect the documents
indexed_documents = document_store.filter_documents()
print(f"Indexed {len(indexed_documents)} documents:")
print(indexed_documents)


#
# Querying the documents
#

# Create the Retrieval + Query pipeline
text_embedder = SentenceTransformersTextEmbedder(
    # model="sentence-transformers/clip-ViT-B-32",
    model="sentence-transformers/clip-ViT-L-14",
    # normalize_embeddings=True,
    progress_bar=False
)
retriever = InMemoryEmbeddingRetriever(document_store=document_store, top_k=7)
doc_type_router = DocumentTypeRouter(
    file_path_meta_field="file_path",
    mime_types=["image/jpeg", "image/png", "application/pdf"]
)
doc_joiner = DocumentJoiner(sort_by_score=False)
doc_to_image = DocumentToImageContent(detail="auto")
chat_prompt_builder = ChatPromptBuilder(
    required_variables=["question"],
    template="""{% message role="system" %}
You are a friendly assistant that answers questions based on provided documents.
{% endmessage %}

{%- message role="user" -%}
Only provide an answer to the question using the images and text passages provided.

== Text-only documents ==
{%- if text_documents|length > 0 %}
{%- for doc in text_documents %}
Text Document [{{ loop.index }}] :
{{ doc.content }}
{% endfor -%}
{%- else %}
No relevant text documents were found.
{% endif %}
== End of text documents ==


Question: {{ question }}
Answer:

{%- if image_contents|length > 0 %}
{%- for img in image_contents -%}
  {{ img | templatize_part }}
{%- endfor -%}
{% endif %}
{%- endmessage -%}
""",
)
llm = OpenAIChatGenerator()

# Create the pipeline
pipe = Pipeline()
pipe.add_component("text_embedder", text_embedder)
pipe.add_component("retriever", retriever)
pipe.add_component("doc_type_router", doc_type_router)
pipe.add_component("doc_joiner", doc_joiner)
pipe.add_component("doc_to_image", doc_to_image)
pipe.add_component("chat_prompt_builder", chat_prompt_builder)
pipe.add_component("llm", llm)

pipe.connect("text_embedder.embedding", "retriever.query_embedding")
pipe.connect("retriever.documents", "doc_type_router.documents")
pipe.connect("doc_type_router.image/jpeg", "doc_joiner.documents")
pipe.connect("doc_type_router.image/png", "doc_joiner.documents")
pipe.connect("doc_type_router.application/pdf", "doc_joiner.documents")
pipe.connect("doc_joiner.documents", "doc_to_image.documents")
pipe.connect("doc_to_image.image_contents", "chat_prompt_builder.image_contents")
pipe.connect("doc_type_router.unclassified", "chat_prompt_builder.text_documents")
pipe.connect("chat_prompt_builder.prompt", "llm.messages")

# Run the pipeline with a query about the apple image
# query = "What is the color of the background of the image with an apple in it?"
query = "What is the color of the background of the image with an apple in it?"
result = pipe.run(
    data={"text_embedder": {"text": query}, "chat_prompt_builder": {"question": query}},
    include_outputs_from={"retriever", "doc_type_router", "chat_prompt_builder"},
)
print(result["llm"]["replies"][0].text)

# Run the pipeline with a query about the docx document
query = "How many confirmed corona cases are there in the US?"
result = pipe.run(
    data={"text_embedder": {"text": query}, "chat_prompt_builder": {"question": query}},
    include_outputs_from={"chat_prompt_builder"},
)
print(result["llm"]["replies"][0].text)

```
</details>


<details>

<summary> Query Pipeline Graph </summary>

![query](https://github.com/user-attachments/assets/38037907-4a65-474b-80a8-33b3088473f6)

</details>

<details>

<summary> Indexing Pipeline Graph </summary>

![indexing](https://github.com/user-attachments/assets/719e1eea-d1ad-4f6b-ab60-a476f9654a88)

</details>

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
@anakin87 I'd appreciate your thoughts on the concept of this PR before I add tests. Also this would be a complete Indexing Example where we mix Image + Text documents together in both indexing and querying. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
