### PR TITLE
test: update Bedrock tests with ComponentInfo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ fmt-check = "ruff check {args} && ruff format --check {args}"
 [tool.hatch.envs.test]
 extra-dependencies = [
   "colorama",                                         # Pipeline checkpoints experiment
-  "transformers[torch,sentencepiece]>=4.51.1,<4.52",  # Pipeline checkpoints experiment
+  "transformers[torch,sentencepiece]>=4.52.4,<4.53",  # Pipeline checkpoints experiment
   "arrow>=1.3.0",                                     # Multimodal experiment - ChatPromptBuilder
   "pypdfium2",                                        # Multimodal experiment - PDFToImageContent
   "pillow",                                           # Multimodal experiment - ImageFileToImageContent, PDFToImageContent


### PR DESCRIPTION
### Related Issues

Tests in experimental are failing (https://github.com/deepset-ai/haystack-experimental/actions/runs/16069230738/job/45349882428?pr=328) after we released a new version of Bedrock, which includes https://github.com/deepset-ai/haystack-core-integrations/pull/2042

### Proposed Changes:
- align Bedrock experimental tests to those in core-integrations
- unrelated: I'm also updating transformers version to keep it aligned with Haystack

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
