### PR TITLE
chore: unpin Haystack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "haystack-ai>=2.15.0",
+  "haystack-ai",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

When testing core integrations, I noticed an unexpected dependency structure:
- Haystack depends on Haystack experimental
- Haystack experimental depends on Haystack >=2.15.0 (pin introduced in https://github.com/deepset-ai/haystack-experimental/pull/332)

This setup reduces the effectiveness of our lower-bounds testing in core integrations:
even when we attempt to test Haystack against older supported versions, the dependency on experimental forces an upgrade to >=2.15.0, overriding those bounds.

This has a few implications:
- It limits flexibility for downstream users and complicates dependencies resolution
- The pin is not necessary, especially now that the breakpoint feature has been merged into Haystack.

### Proposed Changes:
- unpin haystack

### How did you test it?
CI

### Notes for the reviewer
To actually make this change effective, we would need to release a new experimental version.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
