### PR TITLE
refactor: Refactoring in EmbeddingBasedDocumentSplitter

### DIFF
--- a/haystack_experimental/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack_experimental/components/preprocessors/embedding_based_document_splitter.py
@@ -313,9 +313,9 @@ class EmbeddingBasedDocumentSplitter:
         current_split = splits[0]
 
         for split in splits[1:]:
-            # NOTE: This is a naive way to do this. It assumes that the newly merged split is now longer than
-            #       min_length. And it doesn't check that it would not exceed max_length.
-            if len(current_split) < self.min_length:
+            # We merge splits that are smaller than min_length but only if the newly merged split is still below
+            # max_length.
+            if len(current_split) < self.min_length and len(current_split) + len(split) < self.max_length:
                 # Merge with next split
                 current_split += split
             else:

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -341,6 +341,29 @@ class TestEmbeddingBasedDocumentSplitter:
         assert combined in original or original in combined
 
     @pytest.mark.integration
+    def test_trailing_whitespace_is_preserved(self):
+        embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
+        embedder.warm_up()
+
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=embedder, sentences_per_group=1)
+        splitter.warm_up()
+
+        # Normal trailing whitespace
+        text = "The weather today is beautiful.  "
+        result = splitter.run(documents=[Document(content=text)])
+        assert result["documents"][0].content == text
+
+        # Newline at the end
+        text = "The weather today is beautiful.\n"
+        result = splitter.run(documents=[Document(content=text)])
+        assert result["documents"][0].content == text
+
+        # Page break at the end
+        text = "The weather today is beautiful.\f"
+        result = splitter.run(documents=[Document(content=text)])
+        assert result["documents"][0].content == text
+
+    @pytest.mark.integration
     def test_no_extra_whitespaces_between_sentences(self):
         embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
         embedder.warm_up()

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -191,13 +191,13 @@ class TestEmbeddingBasedDocumentSplitter:
         mock_embedder = Mock()
         splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder, min_length=10)
 
-        splits = ["Short", "Also short", "Long enough text", "Another short"]
+        splits = ["Short ", "Also short ", "Long enough text ", "Another short"]
         merged = splitter._merge_small_splits(splits)
 
         assert len(merged) == 3
-        assert "Short Also short" in merged[0]
-        assert "Long enough text" in merged[1]
-        assert "Another short" in merged[2]
+        assert "Short Also short " == merged[0]
+        assert "Long enough text " == merged[1]
+        assert "Another short" == merged[2]
 
     def test_create_documents_from_splits(self):
         mock_embedder = Mock()
@@ -288,7 +288,6 @@ class TestEmbeddingBasedDocumentSplitter:
         assert result["init_parameters"]["min_length"] == 50
         assert result["init_parameters"]["max_length"] == 1000
         assert "document_embedder" in result["init_parameters"]
-
 
     @pytest.mark.integration
     def test_split_document_with_multiple_topics(self):

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -199,6 +199,19 @@ class TestEmbeddingBasedDocumentSplitter:
         assert "Long enough text " == merged[1]
         assert "Another short" == merged[2]
 
+    def test_merge_small_splits_respect_max_length(self):
+        mock_embedder = Mock()
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder, min_length=10, max_length=15)
+
+        splits = ["123456", "123456789", "1234"]
+        merged = splitter._merge_small_splits(splits=splits)
+
+        assert len(merged) == 2
+        # First split remains beneath min_length b/c next split is too long
+        assert "123456" == merged[0]
+        # Second split is merged with third split to get above min_length and still beneath max_length
+        assert "1234567891234" == merged[1]
+
     def test_create_documents_from_splits(self):
         mock_embedder = Mock()
         splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

@davidsbatista I slightly modified your approach for preserving the whitespace by using `rstrip` instead since it's not guaranteed with the NLTK sentence splitter that the sentence splits will always end in a `"."`. You can check out the new implementation in the method `_split_text`

I also went ahead and did some other refactoring to reduce some code duplication and some other small issues I noticed. Like `_merge_small_splits` didn't guarantee that the newly merged splits were still less than `max_length`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added new tests
- Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
