### PR TITLE
fix: update README.md - wrong discussion link for `EmbeddingBasedDocumentSplitter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ that includes it. Once it reaches the end of its lifespan, the experiment will b
 | [`ChatMessageRetriever`][2]           | Memory Component                   | December 2024     | None         | <a href="https://colab.research.google.com/github/deepset-ai/haystack-cookbook/blob/main/notebooks/conversational_rag_using_memory.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>      | [Discuss][4] |
 | [`ChatMessageWriter`][3]              | Memory Component                   | December 2024     | None         | <a href="https://colab.research.google.com/github/deepset-ai/haystack-cookbook/blob/main/notebooks/conversational_rag_using_memory.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>      | [Discuss][4] |
 | [`QueryExpander`][5]                  | Query Expansion Component          | October 2025      | None         | None | [Discuss][6] |
-| [`EmbeddingBasedDocumentSplitter`][7] | EmbeddingBasedDocumentSplitter     | August 2025       | None         | None | [Discuss][7] |
+| [`EmbeddingBasedDocumentSplitter`][8] | EmbeddingBasedDocumentSplitter     | August 2025       | None         | None | [Discuss][7] |
 
 [1]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/chat_message_stores/in_memory.py
 [2]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -56,6 +56,7 @@ that includes it. Once it reaches the end of its lifespan, the experiment will b
 [5]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/query/query_expander.py
 [6]: https://github.com/deepset-ai/haystack-experimental/discussions/346
 [7]: https://github.com/deepset-ai/haystack-experimental/discussions/356
+[8]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/preprocessors/embedding_based_document_splitter.py
 
 ### Adopted experiments
 | Name                                                                                   | Type                                     | Final release |


### PR DESCRIPTION
### Proposed Changes:

- wrong discussion link for `EmbeddingBasedDocumentSplitter`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
