### PR TITLE
chore: Add discussion and cookbook link to OpenAIChatGenerator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ that includes it. Once it reaches the end of its lifespan, the experiment will b
 | [`EmbeddingBasedDocumentSplitter`][8] | EmbeddingBasedDocumentSplitter | August 2025       | None         | None | [Discuss][7]  |
 | [`MultiQueryEmbeddingRetriever`][9]   | MultiQueryEmbeddingRetriever   | November 2025     | None         | None | [Discuss][11] |
 | [`MultiQueryTextRetriever`][10]       | MultiQueryTextRetriever        | November 2025     | None         | None | [Discuss][12] |
-| [`OpenAIChatGenerator`][9]            | Chat Generator Component       | November 2025     | None         | None | [Discuss][10] |
+| [`OpenAIChatGenerator`][9]            | Chat Generator Component       | November 2025     | None         | <a href="https://colab.research.google.com/github/deepset-ai/haystack-cookbook/blob/main/notebooks/hallucination_score_calculator.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> | [Discuss][10] |
 
 [1]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/chat_message_stores/in_memory.py
 [2]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/retrievers/chat_message_retriever.py
@@ -61,7 +61,7 @@ that includes it. Once it reaches the end of its lifespan, the experiment will b
 [7]: https://github.com/deepset-ai/haystack-experimental/discussions/356
 [8]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/preprocessors/embedding_based_document_splitter.py
 [9]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/generators/chat/openai.py
-[10]: https://github.com/deepset-ai/haystack-experimental/discussions/XXX
+[10]: https://github.com/deepset-ai/haystack-experimental/discussions/361
 [11]: https://github.com/deepset-ai/haystack-experimental/discussions/<>
 [12]: https://github.com/deepset-ai/haystack-experimental/discussions/<>
 [13]: https://github.com/deepset-ai/haystack-experimental/blob/main/haystack_experimental/components/retrievers/multi_query_embedding_retriever.py


### PR DESCRIPTION
### Related Issues

- None. Related PR https://github.com/deepset-ai/haystack-experimental/pull/359

### Proposed Changes:

- Add GitHub discussion link and jupyter notebook link to README for experimental OpenAIChatGenerator

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
