### PR TITLE
feat: Add utilities for converting tools into human-in-the-loop tools

### DIFF
--- a/haystack_experimental/tools/__init__.py
+++ b/haystack_experimental/tools/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/haystack_experimental/tools/human_in_the_loop.py
+++ b/haystack_experimental/tools/human_in_the_loop.py
@@ -9,24 +9,45 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
 
-from haystack.tools import Tool, create_tool_from_function
+from haystack.tools import Tool
 
 from haystack_experimental.tools.types.protocol import ConfirmationPrompt, ExecutionPolicy
 
 
 @dataclass
 class ConfirmationResult:
+    """
+    Result of the confirmation prompt.
+
+    :param action: The action chosen by the user ("confirm", "reject", or "modify").
+    :param feedback: Optional feedback message if the action is "reject".
+    :param new_params: Optional new parameters if the action is "modify".
+    """
     action: str   # "confirm" | "reject" | "modify"
     feedback: str | None = None
     new_params: dict[str, Any] | None = None
 
 
-# Different prompt
 class RichConsolePrompt:
-    def __init__(self, console: Console | None = None):
+    """
+    Confirmation prompt using Rich library for enhanced console interaction.
+    """
+    def __init__(self, console: Console | None = None) -> None:
+        """
+        :param console: Optional Rich Console instance. If None, a new Console will be created.
+        """
         self.console = console or Console()
 
     def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+        """
+        Ask for user confirmation before executing a tool.
+
+        :param tool_name: Name of the tool to be executed.
+        :param params: Parameters to be passed to the tool.
+        :returns:
+            ConfirmationResult with action (e.g. "confirm" or "reject"), optional feedback message and new parameters
+            if modified.
+        """
         # Display info
         lines = [f"[bold yellow]Tool:[/bold yellow] {tool_name}"]
         if params:
@@ -55,7 +76,19 @@ class RichConsolePrompt:
 
 
 class SimpleInputPrompt:
+    """
+    Simple confirmation prompt using standard input/output.
+    """
     def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+        """
+        Ask for user confirmation before executing a tool.
+
+        :param tool_name: Name of the tool to be executed.
+        :param params: Parameters to be passed to the tool.
+        :returns:
+            ConfirmationResult with action (e.g. "confirm" or "reject"), optional feedback message and new parameters
+            if modified.
+        """
         print(f"Tool: {tool_name}")
         if params:
             print("Arguments:")
@@ -77,7 +110,21 @@ class SimpleInputPrompt:
 
 
 class DefaultPolicy:
+    """
+    Default execution policy:
+    - If confirmed, run the tool with original params.
+    - If rejected, return a rejection message.
+    - If modified, run the tool immediately with new params.
+    """
     def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+        """
+        Handle the confirmation result and execute the tool accordingly.
+        :param result: The result from the confirmation prompt.
+        :param tool: The tool to potentially execute.
+        :param kwargs: The original parameters for the tool.
+
+        :returns: The result of the tool execution or a rejection message.
+        """
         if result.action == "reject":
             return {
                 "status": "rejected",
@@ -91,44 +138,37 @@ class DefaultPolicy:
 
 
 class AutoConfirmPolicy:
+    """
+    Always confirm and run the tool, ignoring user input.
+    """
     def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+        """
+        Always execute the tool, ignoring any rejection from the user.
+
+        :param result: The result from the confirmation prompt (ignored).
+        :param tool: The tool to execute.
+        :param kwargs: The original parameters for the tool.
+
+        :returns: The result of the tool execution.
+        """
         # Always run, ignore user rejection
         return tool.function(**kwargs)
 
 
-# Wrapper
 def confirmation_wrapper(
     tool: Tool,
     strategy: ConfirmationPrompt,
     policy: ExecutionPolicy = DefaultPolicy(),
 ) -> Tool:
+    """
+    Wrap a tool with a human-in-the-loop confirmation step.
+
+    :param tool: The tool to wrap.
+    :param strategy: The confirmation prompt strategy to use.
+    :param policy: The execution policy to apply based on user input.
+    :return: A new Tool instance with confirmation logic.
+    """
     def wrapped_function(**kwargs: Any) -> Any:
         result = strategy.confirm(tool.name, kwargs)
         return policy.handle(result, tool, kwargs)
     return replace(tool, function=wrapped_function)
-
-
-# Main
-if __name__ == "__main__":
-    def get_bank_balance(account_id: str) -> str:
-        return f"Balance for account {account_id} is $1,234.56"
-
-    balance_tool = create_tool_from_function(
-        function=get_bank_balance,
-        name="get_bank_balance",
-        description="Get the bank balance for a given account ID.",
-    )
-
-    cons = Console()
-    console_tool = confirmation_wrapper(balance_tool, RichConsolePrompt(cons))
-    simple_tool = confirmation_wrapper(balance_tool, SimpleInputPrompt())
-
-    # Use the console version
-    cons.print("\n[bold]Using console confirmation tool:[/bold]")
-    res = console_tool.invoke(account_id="123456")
-    cons.print(f"\n[bold green]Result:[/bold green] {res}")
-
-    # Use the simple input version
-    print("\nUsing simple input confirmation tool:")
-    res = simple_tool.invoke(account_id="123456")
-    print(f"\nResult: {res}")

--- a/haystack_experimental/tools/human_in_the_loop.py
+++ b/haystack_experimental/tools/human_in_the_loop.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+
+from haystack.tools import Tool, create_tool_from_function
+
+from haystack_experimental.tools.types.protocol import ConfirmationPrompt, ExecutionPolicy
+
+
+@dataclass
+class ConfirmationResult:
+    action: str   # "confirm" | "reject" | "modify"
+    feedback: str | None = None
+    new_params: dict[str, Any] | None = None
+
+
+# Different prompt
+class RichConsolePrompt:
+    def __init__(self, console: Console | None = None):
+        self.console = console or Console()
+
+    def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+        # Display info
+        lines = [f"[bold yellow]Tool:[/bold yellow] {tool_name}"]
+        if params:
+            lines.append("\n[bold yellow]Arguments:[/bold yellow]")
+            for k, v in params.items():
+                lines.append(f"\n[cyan]{k}:[/cyan]\n  {v}")
+        self.console.print(Panel("\n".join(lines), title="🔧 Tool Execution Request"))
+
+        # Ask action
+        choice = Prompt.ask(
+            "\nYour choice",
+            choices=["y", "n", "m"],  # confirm, reject, modify
+            default="y",
+        )
+        if choice == "y":
+            return ConfirmationResult(action="confirm")
+        elif choice == "m":
+            new_params = {}
+            for k, v in params.items():
+                new_val = Prompt.ask(f"Modify '{k}'", default=str(v))
+                new_params[k] = new_val
+            return ConfirmationResult(action="modify", new_params=new_params)
+        else:  # reject
+            feedback = Prompt.ask("Feedback message (optional)", default="")
+            return ConfirmationResult(action="reject", feedback=feedback or None)
+
+
+class SimpleInputPrompt:
+    def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+        print(f"Tool: {tool_name}")
+        if params:
+            print("Arguments:")
+            for k, v in params.items():
+                print(f"  {k}: {v}")
+
+        choice = input("Confirm execution? (y=confirm / n=reject / m=modify): ").strip().lower()
+        if choice == "y":
+            return ConfirmationResult(action="confirm")
+        elif choice == "m":
+            new_params = {}
+            for k, v in params.items():
+                new_val = input(f"Modify '{k}' [{v}]: ").strip() or v
+                new_params[k] = new_val
+            return ConfirmationResult(action="modify", new_params=new_params)
+        else:  # modify
+            feedback = input("Feedback message (optional): ").strip()
+            return ConfirmationResult(action="reject", feedback=feedback or None)
+
+
+class DefaultPolicy:
+    def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+        if result.action == "reject":
+            return {
+                "status": "rejected",
+                "tool": tool.name,
+                "feedback": result.feedback or "Tool execution rejected by user",
+            }
+        elif result.action == "modify" and result.new_params:
+            # Run immediately with new params
+            return tool.function(**result.new_params)
+        return tool.function(**kwargs)
+
+
+class AutoConfirmPolicy:
+    def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+        # Always run, ignore user rejection
+        return tool.function(**kwargs)
+
+
+# Wrapper
+def confirmation_wrapper(
+    tool: Tool,
+    strategy: ConfirmationPrompt,
+    policy: ExecutionPolicy = DefaultPolicy(),
+) -> Tool:
+    def wrapped_function(**kwargs: Any) -> Any:
+        result = strategy.confirm(tool.name, kwargs)
+        return policy.handle(result, tool, kwargs)
+    return replace(tool, function=wrapped_function)
+
+
+# Main
+if __name__ == "__main__":
+    def get_bank_balance(account_id: str) -> str:
+        return f"Balance for account {account_id} is $1,234.56"
+
+    balance_tool = create_tool_from_function(
+        function=get_bank_balance,
+        name="get_bank_balance",
+        description="Get the bank balance for a given account ID.",
+    )
+
+    cons = Console()
+    console_tool = confirmation_wrapper(balance_tool, RichConsolePrompt(cons))
+    simple_tool = confirmation_wrapper(balance_tool, SimpleInputPrompt())
+
+    # Use the console version
+    cons.print("\n[bold]Using console confirmation tool:[/bold]")
+    res = console_tool.invoke(account_id="123456")
+    cons.print(f"\n[bold green]Result:[/bold green] {res}")
+
+    # Use the simple input version
+    print("\nUsing simple input confirmation tool:")
+    res = simple_tool.invoke(account_id="123456")
+    print(f"\nResult: {res}")

--- a/haystack_experimental/tools/types/__init__.py
+++ b/haystack_experimental/tools/types/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .protocol import ConfirmationPrompt, ExecutionPolicy
+
+__all__ = ["ConfirmationPrompt", "ExecutionPolicy"]

--- a/haystack_experimental/tools/types/protocol.py
+++ b/haystack_experimental/tools/types/protocol.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from haystack.tools import Tool
+    from haystack_experimental.tools.human_in_the_loop import ConfirmationResult
+
+
+class ConfirmationPrompt(Protocol):
+    def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+        """
+        Ask for user confirmation before executing a tool.
+
+        :param tool_name: Name of the tool to be executed.
+        :param params: Parameters to be passed to the tool.
+        :returns:
+            ConfirmationResult with action (e.g. "confirm" or "reject") and optional feedback message.
+        """
+
+
+class ExecutionPolicy(Protocol):
+    def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+        ...

--- a/haystack_experimental/tools/types/protocol.py
+++ b/haystack_experimental/tools/types/protocol.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 class ConfirmationPrompt(Protocol):
-    def confirm(self, tool_name: str, params: dict[str, Any]) -> ConfirmationResult:
+    def confirm(self, tool_name: str, params: dict[str, Any]) -> "ConfirmationResult":
         """
         Ask for user confirmation before executing a tool.
 
@@ -22,5 +22,5 @@ class ConfirmationPrompt(Protocol):
 
 
 class ExecutionPolicy(Protocol):
-    def handle(self, result: ConfirmationResult, tool: Tool, kwargs: dict[str, Any]) -> Any:
+    def handle(self, result: "ConfirmationResult", tool: "Tool", kwargs: dict[str, Any]) -> Any:
         ...

--- a/haystack_experimental/tools/types/protocol.py
+++ b/haystack_experimental/tools/types/protocol.py
@@ -23,4 +23,14 @@ class ConfirmationPrompt(Protocol):
 
 class ExecutionPolicy(Protocol):
     def handle(self, result: "ConfirmationResult", tool: "Tool", kwargs: dict[str, Any]) -> Any:
+        """
+        Handle the execution policy based on the user's confirmation result.
+
+        :param result: The result from the confirmation prompt.
+        :param tool: The tool to be executed.
+        :param kwargs: The parameters to be passed to the tool.
+
+        :returns:
+            The result of the execution policy (e.g., tool output, rejection message, etc.).
+        """
         ...

--- a/hitl_example.py
+++ b/hitl_example.py
@@ -1,5 +1,12 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from rich.console import Console
 
+from haystack.dataclasses import ChatMessage
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.tools import create_tool_from_function
 
 from haystack_experimental.tools.human_in_the_loop import (
@@ -19,6 +26,10 @@ balance_tool = create_tool_from_function(
     description="Get the bank balance for a given account ID.",
 )
 
+#
+# Example: Run Tool individually with different Prompts
+#
+
 # Use the console version
 cons = Console()
 console_tool = confirmation_wrapper(balance_tool, RichConsolePrompt(cons))
@@ -31,3 +42,20 @@ simple_tool = confirmation_wrapper(balance_tool, SimpleInputPrompt())
 print("\nUsing simple input confirmation tool:")
 res = simple_tool.invoke(account_id="123456")
 print(f"\nResult: {res}")
+
+
+#
+# Example: Running with an Agent
+#
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-4.1"),
+    tools=[console_tool],  # or simple_tool
+    system_prompt="""
+You are a helpful financial assistant. Use the provided tool to get bank balances when needed.
+"""
+)
+
+result = agent.run([ChatMessage.from_user("What's the balance of account 56789?")])
+last_message = result["last_message"]
+cons.print(f"\n[bold green]Agent Result:[/bold green] {last_message.text}")

--- a/hitl_example.py
+++ b/hitl_example.py
@@ -1,0 +1,33 @@
+from rich.console import Console
+
+from haystack.tools import create_tool_from_function
+
+from haystack_experimental.tools.human_in_the_loop import (
+    confirmation_wrapper,
+    SimpleInputPrompt,
+    RichConsolePrompt,
+)
+
+
+def get_bank_balance(account_id: str) -> str:
+    return f"Balance for account {account_id} is $1,234.56"
+
+
+balance_tool = create_tool_from_function(
+    function=get_bank_balance,
+    name="get_bank_balance",
+    description="Get the bank balance for a given account ID.",
+)
+
+# Use the console version
+cons = Console()
+console_tool = confirmation_wrapper(balance_tool, RichConsolePrompt(cons))
+cons.print("\n[bold]Using console confirmation tool:[/bold]")
+res = console_tool.invoke(account_id="123456")
+cons.print(f"\n[bold green]Result:[/bold green] {res}")
+
+# Use the simple input version
+simple_tool = confirmation_wrapper(balance_tool, SimpleInputPrompt())
+print("\nUsing simple input confirmation tool:")
+res = simple_tool.invoke(account_id="123456")
+print(f"\nResult: {res}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 
 dependencies = [
   "haystack-ai",
+  "rich", # For pretty printing in the console used by human-in-the-loop utilities
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/186

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR introduces a human-in-the-loop (HITL) mechanism for tool execution in Haystack, allowing users to confirm, reject, or modify tool invocations interactively. 

- **`haystack_experimental/tools/human_in_the_loop.py`**
  - Implements `ConfirmationResult` dataclass to capture user decisions.
  - Adds `RichConsolePrompt` and `SimpleInputPrompt` for interactive confirmation via Rich or standard input.
  - Defines `DefaultPolicy` and `AutoConfirmPolicy` for handling user responses.
  - Provides `confirmation_wrapper` to wrap any tool with HITL logic.

- **`haystack_experimental/tools/types/protocol.py`**
  - Introduces `ConfirmationPrompt` and `ExecutionPolicy` protocols to allow users to easily customize how their HITL Tools should work.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Provided an example script called `hitl_example.py` which shows how to use these new utility functions to convert existing tools into ones that ask for confirmation. I've also reproduced it here

```python
# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
#
# SPDX-License-Identifier: Apache-2.0

from rich.console import Console

from haystack.dataclasses import ChatMessage
from haystack.components.agents import Agent
from haystack.components.generators.chat import OpenAIChatGenerator
from haystack.tools import create_tool_from_function

from haystack_experimental.tools.human_in_the_loop import (
    confirmation_wrapper,
    SimpleInputPrompt,
    RichConsolePrompt,
)


def get_bank_balance(account_id: str) -> str:
    return f"Balance for account {account_id} is $1,234.56"


balance_tool = create_tool_from_function(
    function=get_bank_balance,
    name="get_bank_balance",
    description="Get the bank balance for a given account ID.",
)

#
# Example: Run Tool individually with different Prompts
#

# Use the console version
cons = Console()
console_tool = confirmation_wrapper(balance_tool, RichConsolePrompt(cons))
cons.print("\n[bold]Using console confirmation tool:[/bold]")
res = console_tool.invoke(account_id="123456")
cons.print(f"\n[bold green]Result:[/bold green] {res}")

# Use the simple input version
simple_tool = confirmation_wrapper(balance_tool, SimpleInputPrompt())
print("\nUsing simple input confirmation tool:")
res = simple_tool.invoke(account_id="123456")
print(f"\nResult: {res}")


#
# Example: Running with an Agent
#

agent = Agent(
    chat_generator=OpenAIChatGenerator(model="gpt-4.1"),
    tools=[console_tool],  # or simple_tool
    system_prompt="""
You are a helpful financial assistant. Use the provided tool to get bank balances when needed.
"""
)

result = agent.run([ChatMessage.from_user("What's the balance of account 56789?")])
last_message = result["last_message"]
cons.print(f"\n[bold green]Agent Result:[/bold green] {last_message.text}")
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
I'd appreciate some guidance on the best place to add this to Haystack. I'm unsure if this should become a part of the main library or if this would be better served in a cookbook or a tutorial. 

The nature of Human in the Loop confirmations I believe can become quite custom which is why I found it difficult to create a generic pattern. I attempted to do this by creating the Protocols `ConfirmationPrompt` and `ExecutionPolicy` so users could easily customize how their Human in the Loop tools would work. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
