### PR TITLE
test: pin transformers<4.57

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ fmt-check = "ruff check {args} && ruff format --check {args}"
 extra-dependencies = [
   "sentence-transformers>=4.1.0",                     # EmbeddingBasedDocumentSplitter
   "nltk>=3.9.1",                                      # EmbeddingBasedDocumentSplitter
+  "transformers>=4.55.4,<4.57",                       # Issue https://github.com/huggingface/transformers/issues/41339
 
   # Type check
   "mypy",


### PR DESCRIPTION
### Related Issues

- fixes failing tests in haystack-experimental
- Transformers 4.57.0 is incompatible with Python 3.9: https://github.com/huggingface/transformers/issues/41339
- related to https://github.com/deepset-ai/haystack/pull/9852

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- pin transformers test dependency <4.57

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
