### PR TITLE
fix: Make experimental Agent compatible with Haystack main and Haystack 2.19

### DIFF
--- a/haystack_experimental/components/agents/agent.py
+++ b/haystack_experimental/components/agents/agent.py
@@ -286,6 +286,9 @@ class Agent(HaystackAgent):
             "snapshot": snapshot,
             **kwargs,
         }
+        # The PR https://github.com/deepset-ai/haystack/pull/9987 removed the unused snapshot parameter from
+        # _runtime_checks. This change will be released in Haystack 2.20.0.
+        # To maintain compatibility with Haystack 2.19 we check the number of parameters and call accordingly.
         if len(inspect.signature(self._runtime_checks).parameters) == 2:
             self._runtime_checks(break_point, snapshot)
         else:
@@ -476,6 +479,9 @@ class Agent(HaystackAgent):
             "snapshot": snapshot,
             **kwargs,
         }
+        # The PR https://github.com/deepset-ai/haystack/pull/9987 removed the unused snapshot parameter from
+        # _runtime_checks. This change will be released in Haystack 2.20.0.
+        # To maintain compatibility with Haystack 2.19 we check the number of parameters and call accordingly.
         if len(inspect.signature(self._runtime_checks).parameters) == 2:
             self._runtime_checks(break_point, snapshot)
         else:


### PR DESCRIPTION
### Related Issues

- fixes failing test for tutorial https://github.com/deepset-ai/haystack-tutorials/actions/runs/18968436340/job/54170222679?pr=414

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- Make experimental Agent compatible with Haystack main and Haystack 2.19. Once Haystack 2.20 is out we can drop the if-check but I thought in the off chance we release a new version of haystack-experimental before we release Haystack 2.20 it would be best to still make sure this works with Haystack 2.19
- Issue arose from this PR https://github.com/deepset-ai/haystack/pull/9987

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
