### PR TITLE
feat: Update `QueryExpander`, `MultiQueryEmbeddingRetriever` and `MultiQueryTextRetriever` to auto warm up at runtime

### DIFF
--- a/haystack_experimental/components/retrievers/multi_query_text_retriever.py
+++ b/haystack_experimental/components/retrievers/multi_query_text_retriever.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.core.serialization import component_to_dict
@@ -57,11 +57,7 @@ class MultiQueryTextRetriever:
     ```
     """  # noqa E501
 
-    def __init__(
-        self,
-        retriever: TextRetriever,
-        max_workers: int = 3,
-    ):
+    def __init__(self, *, retriever: TextRetriever, max_workers: int = 3) -> None:
         """
         Initialize MultiQueryTextRetriever.
 
@@ -82,11 +78,7 @@ class MultiQueryTextRetriever:
             self._is_warmed_up = True
 
     @component.output_types(documents=list[Document])
-    def run(
-        self,
-        queries: List[str],
-        retriever_kwargs: Optional[dict[str, Any]] = None,
-    ) -> dict[str, Any]:
+    def run(self, queries: list[str], retriever_kwargs: Optional[dict[str, Any]] = None) -> dict[str, list[Document]]:
         """
         Retrieve documents using multiple queries in parallel.
 

--- a/test/components/query/test_query_expander.py
+++ b/test/components/query/test_query_expander.py
@@ -46,15 +46,6 @@ class TestQueryExpander:
         assert expander.n_expansions == 3
         assert expander.chat_generator is mock_chat_generator
 
-    def test_run_not_warmed_up_raises_error(self, mock_chat_generator_with_warm_up):
-        expander = QueryExpander(chat_generator=mock_chat_generator_with_warm_up)
-
-        with pytest.raises(
-            RuntimeError,
-            match="The component is not warmed up. Please call the `warm_up` method first.",
-        ):
-            expander.run("test query")
-
     def test_run_warm_up(self, mock_chat_generator_with_warm_up):
         expander = QueryExpander(chat_generator=mock_chat_generator_with_warm_up)
         mock_chat_generator_with_warm_up.run.return_value = {"queries": ["test query"]}

--- a/test/components/retrievers/test_multi_query_embedding_retriever.py
+++ b/test/components/retrievers/test_multi_query_embedding_retriever.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from keyword import kwlist
 
 import numpy as np
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
### Related Issues

- partially address https://github.com/deepset-ai/haystack/issues/9966

- Also fixes failing tests at main due to the introduction of a `warm_up` method to `OpenAIChatGenerator` (e.g. this [failure](https://github.com/deepset-ai/haystack-experimental/actions/runs/19363715231/job/55401527563#step:5:783))

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Auto warmup the underlying components like chat generators, embedders and retrievers at runtime if using the component in isolation and not in a pipeline.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
