### PR TITLE
ci: use ubuntu-slim for lightweight CI jobs

### DIFF
--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -16,7 +16,7 @@ env:
   PYTHON_VERSION: "3.11"
 jobs:
   generate-api-reference:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout this repo
@@ -44,12 +44,12 @@ jobs:
 
 
   sync-api-reference:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: generate-api-reference
 
     steps:
       - name: Checkout Haystack repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: deepset-ai/haystack
           ref: main

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add new issues to project for triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -10,11 +10,16 @@ env:
 
 jobs:
   release-on-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install Hatch
         run: pip install hatch==${{ env.HATCH_VERSION }}

--- a/.github/workflows/workflows_linting.yml
+++ b/.github/workflows/workflows_linting.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ">=1.24.0"
 
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         - tomli
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.9
     hooks:
     - id: actionlint-docker
       args: ["-ignore", "SC2102"]


### PR DESCRIPTION
### Related Issues

- similar to https://github.com/deepset-ai/haystack/pull/10234

### Proposed Changes:
- adopt Ubuntu Slim in some workflows
  - used https://github.com/fchimpan/gh-slimify to identify candidates
  - manually refined this list

### How did you test it?
Most of these workflows are identical to those tested in Haystack

### Notes for the reviewer
If something does not work as expected, we'll figure it out in the next few days and revert specific changes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
