### PR TITLE
chore: test with python 3.10 in the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,12 +102,12 @@ jobs:
           path-to-lcov: coverage.xml
 
       - name: Nightly - run unit tests with Haystack main branch
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         id: nightly-haystack-main
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
-          hatch run test:all
+          hatch run test:unit
 
   integration-tests:
     name: Integration / ${{ matrix.os }}


### PR DESCRIPTION
### Related Issues

- part of 3.10 migration (https://github.com/deepset-ai/haystack/issues/10268)

### Proposed Changes:
- use 3.10 in the CI
- fix the command to install dependencies from Haystack main for nightly tests (similarly to https://github.com/deepset-ai/haystack-core-integrations/pull/2418)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
