### PR TITLE
fix: update Mem0MemoryStore for Mem0 v3 + adapt Agent

### DIFF
--- a/haystack_experimental/components/agents/agent.py
+++ b/haystack_experimental/components/agents/agent.py
@@ -226,7 +226,7 @@ class Agent(HaystackAgent):
         )
 
         # NOTE: difference with parent method to add memory retrieval
-        if self._memory_store:
+        if self._memory_store and messages:
             retrieved_memories = self._memory_store.search_memories(
                 query=messages[-1].text, **memory_store_kwargs if memory_store_kwargs else {}
             )

--- a/haystack_experimental/components/agents/agent.py
+++ b/haystack_experimental/components/agents/agent.py
@@ -178,7 +178,7 @@ class Agent(HaystackAgent):
 
     def _initialize_fresh_execution(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | None,
         streaming_callback: StreamingCallbackT | None,
         requires_async: bool,
         *,

--- a/haystack_experimental/memory_stores/mem0/memory_store.py
+++ b/haystack_experimental/memory_stores/mem0/memory_store.py
@@ -50,26 +50,25 @@ class Mem0MemoryStore:
         user_id: str | None = None,
         run_id: str | None = None,
         agent_id: str | None = None,
-        async_mode: bool = False,
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         """
         Add ChatMessage memories to Mem0.
 
         :param messages: List of ChatMessage objects with memory metadata
-        :param infer: Whether to infer facts from the messages. If False, the whole message will
-            be added as a memory.
+        :param infer: Whether to infer facts from the messages. If False, the whole message will be added as a memory.
+            With `infer=False`, Mem0 returns the added memory ids synchronously. With `infer=True`, Mem0 may return a
+            pending status without any memory ids; in that case, the extracted memories become available via
+            `search_memories` once the server finishes indexing them.
         :param user_id: The user ID to to store and retrieve memories from the memory store.
         :param run_id: The run ID to to store and retrieve memories from the memory store.
         :param agent_id: The agent ID to to store and retrieve memories from the memory store.
             If you want Mem0 to store chat messages from the assistant, you need to set the agent_id.
-        :param async_mode: Whether to add memories asynchronously.
-            If True, the method will return immediately and the memories will be added in the background.
         :param kwargs: Additional keyword arguments to pass to the Mem0 client.add method.
             Note: ChatMessage.meta in the list of messages will be ignored because Mem0 doesn't allow
             passing metadata for each message in the list. You can pass metadata for the whole memory
             by passing the `metadata` keyword argument to the method.
-        :returns: List of objects with the memory_id and the memory
+        :returns: List of objects with the memory_id and the memory.
         """
         added_ids = []
         ids = self._get_ids(user_id, run_id, agent_id)
@@ -85,11 +84,13 @@ class Mem0MemoryStore:
             # we save the role of the message in the metadata
             mem0_messages.append({"content": message.text, "role": message.role.value})
         try:
-            status = self.client.add(messages=mem0_messages, infer=infer, **ids, async_mode=async_mode, **kwargs)
-            if status:
+            status = self.client.add(messages=mem0_messages, infer=infer, **ids, **kwargs)
+            if status and "results" in status:
                 for result in status["results"]:
-                    memory_id = {"memory_id": result.get("id"), "memory": result["memory"]}
-                    added_ids.append(memory_id)
+                    # Mem0 v3 wraps the memory text under a `data` key; older shapes exposed it directly
+                    data = result.get("data")
+                    memory_text = data.get("memory") if isinstance(data, dict) else result.get("memory")
+                    added_ids.append({"memory_id": result.get("id"), "memory": memory_text})
         except Exception as e:
             raise RuntimeError(f"Failed to add memory message: {e}") from e
         return added_ids

--- a/test/memory_stores/test_mem0_memory_store.py
+++ b/test/memory_stores/test_mem0_memory_store.py
@@ -213,15 +213,13 @@ class TestMem0MemoryStore:
         ]
         store.add_memories(messages=user_messages, infer=False, user_id=user_id)
         store.add_memories(messages=assistant_messages, infer=False, agent_id=unique_agent_id)
-        try:
-            assistant_mem = store.search_memories(
-                filters={"field": "agent_id", "operator": "==", "value": unique_agent_id}
-            )
-            user_mem = store.search_memories(filters={"field": "user_id", "operator": "==", "value": user_id})
-            assert len(assistant_mem) == 2
-            assert len(user_mem) == 2
-        finally:
-            store.delete_all_memories(agent_id=unique_agent_id)
+
+        assistant_mem = store.search_memories(
+            filters={"field": "agent_id", "operator": "==", "value": unique_agent_id}
+        )
+        user_mem = store.search_memories(filters={"field": "user_id", "operator": "==", "value": user_id})
+        assert len(assistant_mem) == 2
+        assert len(user_mem) == 2
 
     @pytest.mark.skipif(
         not (os.environ.get("MEM0_API_KEY", None) and os.environ.get("OPENAI_API_KEY", None)),

--- a/test/memory_stores/test_mem0_memory_store.py
+++ b/test/memory_stores/test_mem0_memory_store.py
@@ -92,8 +92,7 @@ class TestMem0MemoryStore:
         """Test adding memories successfully."""
         store, user_id = memory_store
         result = store.add_memories(messages=sample_messages, user_id=user_id)
-        # with infer=True (default), two messages are converted to a single memory
-        assert len(result) == 1
+        assert result == []
 
     @pytest.mark.skipif(
         not os.environ.get("MEM0_API_KEY", None),
@@ -115,9 +114,7 @@ class TestMem0MemoryStore:
         """Test adding memories with metadata."""
         store, user_id = memory_store
         messages = [ChatMessage.from_user("User likes to work with python on NLP projects")]
-        result = store.add_memories(
-            messages=messages, user_id=user_id, metadata={"key": "value"}, async_mode=False
-        )
+        result = store.add_memories(messages=messages, infer=False, user_id=user_id, metadata={"key": "value"})
         assert len(result) == 1
 
     @pytest.mark.skipif(
@@ -201,20 +198,30 @@ class TestMem0MemoryStore:
     def test_role_based_memories(self, memory_store):
         store, user_id = memory_store
         unique_agent_id = _get_unique_user_id()
-        messages = [
+        # in Mem0 v3, to keep user and assistant turns searchable by their own entity id,
+        # they must be added in separate calls
+        user_messages = [
             ChatMessage.from_user("I'm planning to watch a movie tonight. Any recommendations?"),
-            ChatMessage.from_assistant("How about thriller movies? They can be quite engaging."),
             ChatMessage.from_user("I'm not a big fan of thriller movies but I love sci-fi movies."),
+        ]
+        assistant_messages = [
+            ChatMessage.from_assistant("How about thriller movies? They can be quite engaging."),
             ChatMessage.from_assistant(
                 "Got it! Then I would recommend Interstellar or Inception? I would also recommend watching some "
                 "Japanese anime movies."
             ),
         ]
-        store.add_memories(messages=messages, infer=False, user_id=user_id, agent_id=unique_agent_id)
-        assistant_mem = store.search_memories(filters={"field": "agent_id", "operator": "==", "value": unique_agent_id})
-        user_mem = store.search_memories(filters={"field": "user_id", "operator": "==", "value": user_id})
-        assert len(assistant_mem) == 2
-        assert len(user_mem) == 2
+        store.add_memories(messages=user_messages, infer=False, user_id=user_id)
+        store.add_memories(messages=assistant_messages, infer=False, agent_id=unique_agent_id)
+        try:
+            assistant_mem = store.search_memories(
+                filters={"field": "agent_id", "operator": "==", "value": unique_agent_id}
+            )
+            user_mem = store.search_memories(filters={"field": "user_id", "operator": "==", "value": user_id})
+            assert len(assistant_mem) == 2
+            assert len(user_mem) == 2
+        finally:
+            store.delete_all_memories(agent_id=unique_agent_id)
 
     @pytest.mark.skipif(
         not (os.environ.get("MEM0_API_KEY", None) and os.environ.get("OPENAI_API_KEY", None)),


### PR DESCRIPTION
### Related Issues

- failing [tests](https://github.com/deepset-ai/haystack-experimental/actions/runs/24541275954) due to Mem0 v3 release: https://docs.mem0.ai/migration/oss-v2-to-v3

### Proposed Changes:
- Mem0 v3
  - remove `async_mode` parameter (removed in underlying API)
  - handle new results wrapping
  - adapt tests
- Adapt Agent for Haystack 2.27.0

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
