### PR TITLE
fix: fix _initialize_fresh_execution types for Haystack 2.28

### DIFF
--- a/haystack_experimental/components/agents/agent.py
+++ b/haystack_experimental/components/agents/agent.py
@@ -178,7 +178,7 @@ class Agent(HaystackAgent):
 
     def _initialize_fresh_execution(
         self,
-        messages: list[ChatMessage] | None,
+        messages: list[ChatMessage],
         streaming_callback: StreamingCallbackT | None,
         requires_async: bool,
         *,


### PR DESCRIPTION
### Related Issues

- failing mypy on main: https://github.com/deepset-ai/haystack-experimental/actions/runs/24707914328/job/72265295324

### Proposed Changes:
- align `_initialize_fresh_execution` signature to Haystack 2.28 (`messages` is mandatory)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
