### PR TITLE
test: make Summarizer test_from_dict run without api keys

### DIFF
--- a/test/components/summarizers/test_summarizer.py
+++ b/test/components/summarizers/test_summarizer.py
@@ -80,7 +80,8 @@ class TestSummarizer:
         assert init_params["summarize_recursively"] is True
         assert init_params["split_overlap"] == 25
 
-    def test_from_dict(self):
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "placeholder")
         mock_generator = Mock()
         mock_generator.to_dict = Mock(
             return_value={
@@ -204,4 +205,3 @@ class TestSummarizer:
         assert len(result["documents"]) == 1
         assert "summary" in result["documents"][0].meta
         assert len(result["documents"][0].meta["summary"]) < len(doc.content)
-


### PR DESCRIPTION
### Related Issues

- tests failing on PRs from forks/dependabot: https://github.com/deepset-ai/haystack-experimental/actions/runs/25402301455/job/74504669564?pr=471

### Proposed Changes:
- test: make Summarizer test_from_dict run without api keys

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
