### PR TITLE
build: add supply chain hardening via uv exclude-newer and pip uploaded-prior-to

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 1
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,3 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 1
-
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    cooldown:
-      default-days: 1

--- a/.github/workflows/CI_check_api_ref.yml
+++ b/.github/workflows/CI_check_api_ref.yml
@@ -17,8 +17,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch
+        run: pip install --uploaded-prior-to=P1D hatch
 
       - name: Generate API references
         run: hatch run docs

--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
 
       - name: Generate API reference
         run: hatch run docs

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
 
       - name: Build Haystack Experimental
         run: hatch build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
 
       - name: Ruff - check format and linting
         run: hatch run fmt-check
@@ -87,8 +90,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
 
       - name: Run
         run: hatch run test:unit
@@ -128,8 +134,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
 
       # Do not authenticate on PRs from forks and on PRs created by dependabot
       - name: AWS authentication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ include = ["/haystack_experimental"]
 [tool.hatch.build.targets.wheel]
 packages = ["haystack_experimental"]
 
+[tool.uv]
+exclude-newer = "24 hours"
+
+[[tool.uv.exclude-newer-package]]
+package = "haystack-pydoc-tools"
+
 [tool.codespell]
 ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge,ist"
 quiet-level = 3


### PR DESCRIPTION
### Related Issues

- Similar to Haystack PR https://github.com/deepset-ai/haystack/pull/11170
- Similar to Haystack Core Integrations PR https://github.com/deepset-ai/haystack-core-integrations/pull/3258

Given the short time window of typical supply-chain attacks, we should use uv `exclude-newer` and pip `--uploaded-prior-to` to improve security

### Changes

**`pyproject.toml`** — uv `exclude-newer` guardrail:
- Adds `exclude-newer = "24 hours"` under `[tool.uv]`, which tells uv to ignore any package version published within the last 24 hours during resolution.
- Adds `exclude-newer-package` exemption for `haystack-pydoc-tools` (first-party package) so freshly-published releases are always resolvable.

**`.github/dependabot.yml`** — Dependabot cooldown:
- Adds `cooldown.default-days: 1` to `github-actions` entries, so Dependabot won't open bump PRs for versions published less than 1 day ago.

**`--uploaded-prior-to`** — pip guardrail:
- Upgrades pip before each pip install step and adds `--uploaded-prior-to=P1D` to all direct `pip install` commands in CI workflows (pip 26.1+).

### How did you test it?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-experimental/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-experimental/blob/main/CODE_OF_CONDUCT.md).
- I have updated the related issue with new insights and changes.
- I added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)