### PR TITLE
ci: use `python -m pip` to upgrade pip in workflows

### DIFF
--- a/.github/workflows/CI_check_api_ref.yml
+++ b/.github/workflows/CI_check_api_ref.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.13"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch

--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
@@ -88,7 +88,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}
@@ -132,7 +132,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install Hatch
         run: pip install --uploaded-prior-to=P1D hatch==${{ env.HATCH_VERSION }}


### PR DESCRIPTION
### Related Issues

- [Failing workflow](https://github.com/deepset-ai/haystack-experimental/actions/runs/26746132095)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

  The CI was failing on the `windows-latest` runner with:

  > ERROR: To modify pip, please run the following command:
  > C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe -m pip install --upgrade pip

On Windows, invoking `pip install --upgrade pip` through the `pip.exe` entry point trips pip's `protect_pip_from_modification_on_windows` guard: pip cannot replace its own running executable (Windows file locking), so it refuses the operation and points to the module form instead.

  This PR switches all workflows to `python -m pip install --upgrade pip`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
