### PR TITLE
chore: fix README for ruff 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,7 @@ from haystack import component
 
 
 @component
-class FoobarGenerator:
-    ...
-
+class FoobarGenerator: ...
 ```
 
 When the experiment overrides an existing feature, the new symbol should be created at the same path in the experimental
@@ -144,8 +142,7 @@ from haystack.core.pipeline import Pipeline as HaystackPipeline
 
 class Pipeline(HaystackPipeline):
     # Any new experimental method that doesn't exist in the original class
-    def run_async(self, inputs) -> Dict[str, Dict[str, Any]]:
-        ...
+    def run_async(self, inputs) -> Dict[str, Dict[str, Any]]: ...
 
     # Existing methods with breaking changes to their signature, like adding a new mandatory param
     def to_dict(self, new_param: str) -> Dict[str, Any]:
@@ -153,7 +150,6 @@ class Pipeline(HaystackPipeline):
         print(new_param)
         # call the original method
         return super().to_dict()
-
 ```
 
 ## Contributing


### PR DESCRIPTION
### Related Issues

- failing format test (https://github.com/deepset-ai/haystack-experimental/actions/runs/30056237068/job/89368408544) due to ruff 0.16.0 also checking code blocks in Markdown (https://astral.sh/blog/ruff-v0.16.0#markdown-code-block-formatting)

### Proposed Changes:
- format README

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
